### PR TITLE
Handle missing dependency blocks in detectTechStack

### DIFF
--- a/lib/brownfield-analyzer.js
+++ b/lib/brownfield-analyzer.js
@@ -89,7 +89,10 @@ class BrownfieldAnalyzer {
       const packageJson = await fs.readJson(packageJsonPath);
       stack.language = 'JavaScript/TypeScript';
 
-      const deps = { ...packageJson.dependencies, ...packageJson.devDependencies };
+      const deps = {
+        ...(packageJson.dependencies || {}),
+        ...(packageJson.devDependencies || {}),
+      };
 
       // Framework detection
       if (deps.react || deps['react-native']) {

--- a/test/brownfield-analyzer.test.js
+++ b/test/brownfield-analyzer.test.js
@@ -1,0 +1,48 @@
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('fs-extra');
+const { BrownfieldAnalyzer } = require('../lib/brownfield-analyzer');
+
+describe('BrownfieldAnalyzer.detectTechStack', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-brownfield-'));
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.remove(tempDir);
+    }
+  });
+
+  it.each([
+    [
+      'without a dependencies block',
+      {
+        name: 'no-deps',
+        version: '1.0.0',
+        devDependencies: {
+          jest: '^29.0.0',
+        },
+      },
+    ],
+    [
+      'without a devDependencies block',
+      {
+        name: 'no-dev-deps',
+        version: '1.0.0',
+        dependencies: {
+          react: '^18.0.0',
+        },
+      },
+    ],
+  ])('resolves %s', async (_, packageJson) => {
+    await fs.writeJson(path.join(tempDir, 'package.json'), packageJson);
+    const analyzer = new BrownfieldAnalyzer(tempDir);
+
+    await expect(analyzer.detectTechStack()).resolves.toMatchObject({
+      language: 'JavaScript/TypeScript',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- guard `detectTechStack` against missing dependency blocks in package.json files
- add regression coverage to ensure dependency detection works when one block is absent

## Testing
- npm test -- brownfield-analyzer

------
https://chatgpt.com/codex/tasks/task_e_68dd89fec48883268da41c2694beea02