### PR TITLE
Add Codex CLI launcher and documentation updates

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -13,19 +13,26 @@ BMAD-Invisible provides a **natural conversational interface** that guides you t
 ```bash
 # Navigate to your project directory (or create a new one)
 mkdir my-project && cd my-project
-
-# Run this ONE command - it does everything!
-npx bmad-invisible@latest start
 ```
 
-Done! This automatically:
+Pick the assistant CLI you want and run the matching command:
+
+```bash
+# Claude Code CLI flow - one command does everything
+npx bmad-invisible@latest start
+
+# Codex CLI flow - same experience via Codex CLI
+npx bmad-invisible-codex@latest start
+```
+
+Done! Either command automatically:
 
 - Creates `package.json` if needed
 - Sets up project structure
 - Installs all dependencies
 - Launches the chat interface
 
-> **💡 Tip**: Always use `@latest` to avoid npx cache issues!
+> **💡 Tip**: Always use `@latest` to avoid npx cache issues on either flow!
 
 ### Option 1b: NPX Step-by-Step
 
@@ -39,8 +46,11 @@ npx bmad-invisible@latest init
 # Install dependencies
 npm install
 
-# Start chatting!
+# Start chatting with Claude CLI
 npm run bmad:chat
+
+# ...or chat via Codex CLI
+npm run bmad:codex
 ```
 
 ### Option 2: Global Installation
@@ -53,7 +63,8 @@ npm install -g bmad-invisible
 cd your-project
 bmad-invisible init
 bmad-invisible build
-bmad-invisible chat
+bmad-invisible chat             # Claude CLI flow
+bmad-invisible-codex chat       # Codex CLI flow
 ```
 
 ### Option 3: Local Development
@@ -69,13 +80,18 @@ npm install
 # Build the MCP server
 npm run build:mcp
 
-# Start conversation
+# Start conversation (Claude CLI)
 npm run chat
+
+# ...or Codex CLI flow
+npm run codex
 ```
 
 ## Prerequisites
 
-You need **Claude Code CLI** installed (uses your Claude Pro subscription):
+You need one of the supported conversational CLIs installed:
+
+### Claude Code CLI
 
 ```bash
 # Check if installed
@@ -85,6 +101,15 @@ claude --version
 # https://claude.ai/code
 ```
 
+### Codex CLI
+
+```bash
+# Check if installed
+codex --version
+
+# If not installed, follow the setup instructions in your Codex workspace
+```
+
 ## Usage
 
 ### Quick Commands
@@ -92,13 +117,16 @@ claude --version
 ```bash
 npx bmad-invisible init        # Initialize in project
 npx bmad-invisible build       # Build MCP server
-npx bmad-invisible chat        # Start conversation
+npx bmad-invisible chat        # Start conversation (Claude CLI)
+npx bmad-invisible-codex chat  # Start conversation (Codex CLI)
 npx bmad-invisible test        # Run tests
 npx bmad-invisible validate    # Validate config
 npx bmad-invisible help        # Show all commands
 ```
 
 ### Example Session
+
+Start the CLI you prefer (`npm run chat` for Claude, `npm run codex` for Codex) and you'll see an experience like this:
 
 ```
 🎯 Starting BMAD Invisible Orchestrator...

--- a/README.md
+++ b/README.md
@@ -37,24 +37,37 @@ The orchestrator automatically selects the appropriate lane based on task comple
 
 - Node.js ≥ 20.0.0
 - npm ≥ 9.0.0
-- **Claude Code CLI** (uses your Claude Pro subscription - no API keys needed!)
+- Choose your assistant CLI:
+  - **Claude Code CLI** (uses your Claude Pro subscription - no API keys needed!)
+  - **Codex CLI** (uses OpenAI's Codex workspace experience)
 
 ### Installation
 
 #### Option 1: NPX One-Command Setup (Easiest!)
+
+Pick the assistant CLI you want to work with and run the matching command:
+
+**Claude Code CLI Flow**
 
 ```bash
 # Just run this - it does everything!
 npx bmad-invisible@latest start
 ```
 
-That's it! This single command will:
+**Codex CLI Flow**
+
+```bash
+# Same experience, powered by Codex CLI
+npx bmad-invisible-codex@latest start
+```
+
+That's it! Each command will:
 
 - Create project structure
 - Install all dependencies
 - Launch the chat interface
 
-> **💡 Tip**: Always use `@latest` to ensure you get the newest version!
+> **💡 Tip**: Always use `@latest` to ensure you get the newest version of either flow!
 
 #### Option 1b: NPX Step-by-Step
 
@@ -65,8 +78,11 @@ npx bmad-invisible@latest init
 # Install dependencies
 npm install
 
-# Start chatting!
+# Start chatting with Claude CLI
 npm run bmad:chat
+
+# ...or chat via Codex CLI
+npm run bmad:codex
 ```
 
 #### Option 2: Global Installation
@@ -80,7 +96,8 @@ bmad-invisible init
 
 # Build and chat
 bmad-invisible build
-bmad-invisible chat
+bmad-invisible chat             # Claude CLI flow
+bmad-invisible-codex chat       # Codex CLI flow
 ```
 
 #### Option 3: Local Development
@@ -96,11 +113,14 @@ npm install
 # Build the MCP server
 npm run build:mcp
 
-# Start conversational interface
+# Start conversational interface (Claude CLI)
 npm run chat
+
+# ...or Codex CLI flow
+npm run codex
 ```
 
-> **Note**: This uses the Model Context Protocol (MCP) with Claude Code CLI. No API costs - it leverages your existing Claude Pro subscription!
+> **Note**: Both flows use the Model Context Protocol (MCP) with your chosen CLI. Claude Code CLI leverages your existing Claude Pro subscription, while Codex CLI uses your Codex workspace access.
 
 ## 📖 How It Works
 
@@ -131,6 +151,8 @@ Assistant: "Here's the technical approach..."
 ```
 
 ## 💡 Usage Examples
+
+Run whichever CLI you prefer (`npm run chat` for Claude, `npm run codex` for Codex). The experience looks like this:
 
 ### Example 1: Simple App Project
 

--- a/bin/bmad-codex
+++ b/bin/bmad-codex
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+/**
+ * BMAD Invisible Orchestrator - Codex Interface
+ * Launches Codex CLI with MCP server and orchestrator agent
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// Get paths
+const rootDir = path.join(__dirname, '..');
+const mcpConfigPath = path.join(rootDir, 'mcp', 'bmad-config.json');
+const orchestratorPath = path.join(rootDir, 'agents', 'invisible-orchestrator.md');
+
+// Check if files exist
+if (!fs.existsSync(mcpConfigPath)) {
+  console.error('Error: MCP config not found. Run: npm run build:mcp');
+  process.exit(1);
+}
+
+if (!fs.existsSync(orchestratorPath)) {
+  console.error('Error: Orchestrator agent not found');
+  process.exit(1);
+}
+
+// Read orchestrator content and strip YAML frontmatter
+let orchestratorContent = fs.readFileSync(orchestratorPath, 'utf8');
+
+// Remove YAML frontmatter (everything between --- markers)
+orchestratorContent = orchestratorContent.replace(/^---\n[\s\S]*?\n---\n/, '');
+
+// Build Codex command
+const codexArgs = ['--mcp-config', mcpConfigPath, '--append-system-prompt', orchestratorContent];
+
+// Add any additional args from user
+const userArgs = process.argv.slice(2);
+if (userArgs.length > 0) {
+  codexArgs.push(...userArgs);
+}
+
+console.log('🎯 Starting BMAD Invisible Orchestrator (Codex)...');
+console.log('📡 MCP Server: bmad-invisible-orchestrator');
+console.log('🤖 Agent: Invisible BMAD Orchestrator');
+console.log('💬 Type your project idea to begin!\n');
+
+// Launch Codex CLI
+const codex = spawn('codex', codexArgs, {
+  stdio: 'inherit',
+  shell: false,
+});
+
+codex.on('error', (error) => {
+  console.error('Error launching Codex CLI:', error.message);
+  console.error('\nMake sure Codex CLI is installed and in your PATH');
+  process.exit(1);
+});
+
+codex.on('exit', (code) => {
+  process.exit(code || 0);
+});

--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -14,23 +14,38 @@ const fs = require('fs');
 const path = require('path');
 
 const [, , command, ...args] = process.argv;
+const scriptFileName = path.basename(process.argv[1] || '');
+const isCodexVariant = scriptFileName.includes('codex');
+const chatLauncherName = isCodexVariant ? 'bmad-codex' : 'bmad-chat';
+const cliDisplayName = isCodexVariant ? 'Codex CLI' : 'Claude Code CLI';
+const packageCommand = isCodexVariant ? 'bmad-invisible-codex' : 'bmad-invisible';
+const chatCommandLabel = isCodexVariant
+  ? 'Start conversational interface (requires Codex CLI)'
+  : 'Start conversational interface (requires Claude CLI)';
+const startCommandSummary = isCodexVariant
+  ? '🚀 ONE-COMMAND SETUP: init + install + codex chat (recommended!)'
+  : '🚀 ONE-COMMAND SETUP: init + install + chat (recommended!)';
+const chatScriptName = isCodexVariant ? 'bmad:codex' : 'bmad:chat';
+const chatScriptValue = isCodexVariant ? 'bmad-invisible-codex chat' : 'bmad-invisible chat';
+const startChatBanner = isCodexVariant
+  ? '\\n🎯 Starting BMAD Invisible Orchestrator (Codex)...\\n'
+  : '\\n🎯 Starting BMAD Invisible Orchestrator...\\n';
 
 // Get current package version
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
 const currentVersion = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version;
 
-// Show help if no command provided
-if (!command || command === '--help' || command === '-h') {
+const printHelp = () => {
   console.log(`
 BMAD Invisible - Zero-knowledge AI orchestration (v${currentVersion})
 
 Usage:
-  npx bmad-invisible@latest <command> [options]
+  npx ${packageCommand}@latest <command> [options]
 
 Commands:
-  start                🚀 ONE-COMMAND SETUP: init + install + chat (recommended!)
+  start                ${startCommandSummary}
   init                 Initialize BMAD-invisible in current project
-  chat                 Start conversational interface (requires Claude CLI)
+  chat                 ${chatCommandLabel}
   install              Install BMAD-invisible globally
   build                Build MCP server
   test                 Run test suite
@@ -38,15 +53,23 @@ Commands:
   help                 Show this help message
 
 Examples:
-  npx bmad-invisible@latest start      # 🚀 Do everything in one command!
-  npx bmad-invisible@latest init       # Setup in current project
-  npm run bmad:chat                    # Start conversation (after install)
+  npx ${packageCommand}@latest start      # 🚀 Do everything in one command!
+  npx ${packageCommand}@latest init       # Setup in current project
+  npm run ${chatScriptName}                    # Start conversation (after install)
+
+Required tooling:
+  - ${cliDisplayName} available on your PATH
 
 💡 Tip: Always use @latest to get the newest version:
-   npx bmad-invisible@latest start
+   npx ${packageCommand}@latest start
 
 For more information: https://github.com/bacoco/BMAD-invisible
 `);
+};
+
+// Show help if no command provided
+if (!command || command === '--help' || command === '-h') {
+  printHelp();
   process.exit(0);
 }
 
@@ -77,7 +100,7 @@ const commands = {
     });
 
     // Start chat
-    console.log('\n🎯 Starting BMAD Invisible Orchestrator...\n');
+    console.log(startChatBanner);
     await commands.chat();
   },
 
@@ -145,9 +168,10 @@ const commands = {
     packageJson.scripts = packageJson.scripts || {};
 
     const scriptsToAdd = {
-      'bmad:chat': 'bmad-invisible chat',
       'bmad:build': 'bmad-invisible build',
     };
+
+    scriptsToAdd[chatScriptName] = chatScriptValue;
 
     let scriptsAdded = false;
     for (const [key, value] of Object.entries(scriptsToAdd)) {
@@ -178,11 +202,15 @@ Next steps:
   1. Install dependencies:
      npm install
 
-  2. Install Claude Code CLI if not already installed:
-     npm install -g @anthropic-ai/claude-code
+  2. Install ${cliDisplayName} if not already installed:
+     ${
+       isCodexVariant
+         ? 'Follow OpenAI Codex CLI installation instructions to add the `codex` command to your PATH'
+         : 'npm install -g @anthropic-ai/claude-code'
+     }
 
   3. Start chatting:
-     npm run bmad:chat
+     npm run ${chatScriptName}
 
 For detailed documentation, visit:
   https://github.com/bacoco/BMAD-invisible
@@ -193,12 +221,12 @@ For detailed documentation, visit:
     // Check if bmad-invisible is installed locally first
     const localInstall = path.join(process.cwd(), 'node_modules', 'bmad-invisible');
     const chatScript = fs.existsSync(localInstall)
-      ? path.join(localInstall, 'bin', 'bmad-chat')
-      : path.join(__dirname, 'bmad-chat');
+      ? path.join(localInstall, 'bin', chatLauncherName)
+      : path.join(__dirname, chatLauncherName);
 
     if (!fs.existsSync(chatScript)) {
       console.error('❌ BMAD-invisible not found. Please run "npm install" first.');
-      console.error('   Or initialize with: npx bmad-invisible init && npm install');
+      console.error(`   Or initialize with: npx ${packageCommand} init && npm install`);
       process.exit(1);
     }
 
@@ -223,7 +251,7 @@ For detailed documentation, visit:
     child.on('exit', (code) => {
       if (code === 0) {
         console.log('\n✅ BMAD-invisible installed globally!');
-        console.log('You can now use: bmad-invisible <command>');
+        console.log(`You can now use: ${packageCommand} <command>`);
       }
       process.exit(code || 0);
     });
@@ -287,32 +315,7 @@ For detailed documentation, visit:
 
   help: () => {
     // Show help message
-    console.log(`
-BMAD Invisible - Zero-knowledge AI orchestration (v${currentVersion})
-
-Usage:
-  npx bmad-invisible@latest <command> [options]
-
-Commands:
-  start                🚀 ONE-COMMAND SETUP: init + install + chat (recommended!)
-  init                 Initialize BMAD-invisible in current project
-  chat                 Start conversational interface (requires Claude CLI)
-  install              Install BMAD-invisible globally
-  build                Build MCP server
-  test                 Run test suite
-  validate             Validate configuration
-  help                 Show this help message
-
-Examples:
-  npx bmad-invisible@latest start      # 🚀 Do everything in one command!
-  npx bmad-invisible@latest init       # Setup in current project
-  npm run bmad:chat                    # Start conversation (after install)
-
-💡 Tip: Always use @latest to get the newest version:
-   npx bmad-invisible@latest start
-
-For more information: https://github.com/bacoco/BMAD-invisible
-`);
+    printHelp();
   },
 };
 
@@ -320,7 +323,7 @@ For more information: https://github.com/bacoco/BMAD-invisible
 const handler = commands[command];
 if (!handler) {
   console.error(`❌ Unknown command: ${command}`);
-  console.log('Run "npx bmad-invisible help" for usage information.');
+  console.log(`Run "npx ${packageCommand} help" for usage information.`);
   process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -22,14 +22,17 @@
   "author": "Loic Bacoco",
   "main": "tools/cli.js",
   "bin": {
-    "bmad-invisible": "bin/bmad-invisible"
+    "bmad-invisible": "bin/bmad-invisible",
+    "bmad-invisible-codex": "bin/bmad-invisible"
   },
   "scripts": {
+    "bmad:codex": "bmad-invisible-codex chat",
     "build": "node tools/cli.js build",
     "build:agents": "node tools/cli.js build --agents-only",
     "build:mcp": "tsc -p mcp/tsconfig.json",
     "build:teams": "node tools/cli.js build --teams-only",
     "chat": "node bin/bmad-chat",
+    "codex": "node bin/bmad-codex",
     "fix": "npm run format && npm run lint:fix",
     "flatten": "node tools/flattener/main.js",
     "format": "prettier --write \"**/*.{js,cjs,mjs,json,md,yaml}\"",


### PR DESCRIPTION
## Summary
- add a Codex CLI launcher and teach the main CLI to dynamically target Claude or Codex variants
- expose the new Codex launcher through the package bin map and npm scripts
- document the Codex flow alongside Claude in the README and QUICKSTART guides

## Testing
- npx prettier --check README.md QUICKSTART.md bin/bmad-invisible bin/bmad-codex package.json

------
https://chatgpt.com/codex/tasks/task_e_68dd91ae2900832695478d4f3b28b97e