### PR TITLE
Fix dependency merging in brownfield analyzer

### DIFF
--- a/lib/brownfield-analyzer.js
+++ b/lib/brownfield-analyzer.js
@@ -90,8 +90,8 @@ class BrownfieldAnalyzer {
       stack.language = 'JavaScript/TypeScript';
 
       const deps = {
-        ...packageJson.dependencies,
-        ...packageJson.devDependencies,
+        ...(packageJson.dependencies ?? {}),
+        ...(packageJson.devDependencies ?? {}),
       };
 
       // Framework detection


### PR DESCRIPTION
## Summary
- default the dependencies and devDependencies blocks to empty objects before merging in `detectTechStack`
- keep the existing feature detection using the safely merged dependency map

## Testing
- npm test -- test/brownfield-analyzer.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de270cbd0483269c82f747045e219f