### PR TITLE
Handle MCP agent parse failures with structured error

### DIFF
--- a/src/mcp-server/runtime.ts
+++ b/src/mcp-server/runtime.ts
@@ -32,16 +32,28 @@ export interface AgentTriggerParseError {
   };
 }
 
+/**
+ * Builds a structured parse error for agent trigger failures.
+ *
+ * @param agentId - The ID of the agent that failed to parse
+ * @param rawResponse - The unparsable response from the agent
+ * @param error - The error that occurred during parsing
+ * @param context - The context passed to the agent
+ * @param guidance - Optional custom guidance message for the error
+ * @returns A structured AgentTriggerParseError with debugging metadata
+ */
 function buildParseError({
   agentId,
   rawResponse,
   error,
   context,
+  guidance,
 }: {
   agentId: string;
   rawResponse: unknown;
   error: unknown;
   context: any;
+  guidance?: string;
 }): AgentTriggerParseError {
   let stringified = "";
   if (typeof rawResponse === "string") {
@@ -66,7 +78,7 @@ function buildParseError({
           message: String(error),
         };
 
-  const contextMetadata = (() => {
+  const contextMetadata: { provided: boolean; keys?: string[] } = (() => {
     if (!context || typeof context !== "object") {
       return { provided: Boolean(context) };
     }
@@ -89,7 +101,8 @@ function buildParseError({
     rawSnippet: snippet,
     rawResponse,
     guidance:
-      "Ensure the agent returns valid JSON matching the documented contract before attempting a phase transition.",
+      guidance ??
+      "Ensure the agent returns valid JSON matching the documented contract.",
     cause,
     contextMetadata,
   };

--- a/test/phase-transition.checkTransition.test.js
+++ b/test/phase-transition.checkTransition.test.js
@@ -89,4 +89,91 @@ describe('checkTransition', () => {
       shouldTransition: false,
     });
   });
+
+  it('returns null when detector returns null or undefined', async () => {
+    const executeTransitionSpy = jest.spyOn(phaseTransition, 'executeTransition');
+    const triggerAgent = jest.fn().mockResolvedValue(null);
+    const triggerCommand = jest.fn().mockResolvedValue({ success: true });
+    const updateProjectState = jest.fn().mockResolvedValue();
+    const saveDeliverable = jest.fn().mockResolvedValue();
+    const loadPhaseContext = jest.fn().mockResolvedValue({ newContext: true });
+
+    phaseTransition.bindDependencies({
+      triggerAgent,
+      triggerCommand,
+      updateProjectState,
+      saveDeliverable,
+      loadPhaseContext,
+    });
+
+    const conversationContext = { history: [] };
+    const result = await phaseTransition.checkTransition(
+      conversationContext,
+      'Some message',
+      'analyst',
+    );
+
+    expect(triggerAgent).toHaveBeenCalled();
+    expect(executeTransitionSpy).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when detector returns a partial error object (missing required fields)', async () => {
+    const executeTransitionSpy = jest.spyOn(phaseTransition, 'executeTransition');
+    const triggerAgent = jest.fn().mockResolvedValue({
+      errorType: 'agent_parse_error',
+      // Missing agentId and ok fields - should not be recognized as parse error
+    });
+    const triggerCommand = jest.fn().mockResolvedValue({ success: true });
+    const updateProjectState = jest.fn().mockResolvedValue();
+    const saveDeliverable = jest.fn().mockResolvedValue();
+    const loadPhaseContext = jest.fn().mockResolvedValue({ newContext: true });
+
+    phaseTransition.bindDependencies({
+      triggerAgent,
+      triggerCommand,
+      updateProjectState,
+      saveDeliverable,
+      loadPhaseContext,
+    });
+
+    const conversationContext = { history: [] };
+    const result = await phaseTransition.checkTransition(
+      conversationContext,
+      'Some message',
+      'analyst',
+    );
+
+    expect(triggerAgent).toHaveBeenCalled();
+    expect(executeTransitionSpy).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('handles non-object detector responses gracefully', async () => {
+    const executeTransitionSpy = jest.spyOn(phaseTransition, 'executeTransition');
+    const triggerAgent = jest.fn().mockResolvedValue('invalid-string-response');
+    const triggerCommand = jest.fn().mockResolvedValue({ success: true });
+    const updateProjectState = jest.fn().mockResolvedValue();
+    const saveDeliverable = jest.fn().mockResolvedValue();
+    const loadPhaseContext = jest.fn().mockResolvedValue({ newContext: true });
+
+    phaseTransition.bindDependencies({
+      triggerAgent,
+      triggerCommand,
+      updateProjectState,
+      saveDeliverable,
+      loadPhaseContext,
+    });
+
+    const conversationContext = { history: [] };
+    const result = await phaseTransition.checkTransition(
+      conversationContext,
+      'Some message',
+      'analyst',
+    );
+
+    expect(triggerAgent).toHaveBeenCalled();
+    expect(executeTransitionSpy).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- add a typed parse-error contract for MCP agent responses with context metadata
- propagate structured errors through phase transition hooks and the detect_phase tool response
- cover malformed agent payloads with a unit test ensuring the new contract is surfaced

## Testing
- npm test -- phase-transition.checkTransition.test.js

------
https://chatgpt.com/codex/tasks/task_e_68df72b3c988832680183a79a33db90e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a structured parse-error type for agent trigger parse failures, providing richer context for troubleshooting.
- Bug Fixes
  - Prevents unintended phase transitions when detector results are malformed or unparsable.
  - Handles unsupported/invalid agent responses gracefully with clear structured feedback.
- Improvements
  - More informative logging for parse and transition errors.
  - Early exit on unparsable results to avoid unnecessary processing.
- Tests
  - Updated tests to validate structured error behavior and non-transition outcomes.
- Chores
  - No changes to public API signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->