### PR TITLE
Update shadcn components.json generation

### DIFF
--- a/bin/bmad-invisible
+++ b/bin/bmad-invisible
@@ -465,6 +465,8 @@ const commands = {
         // Detect Tailwind config variant (.ts vs .js)
         if (fs.existsSync(path.join(projectRoot, 'tailwind.config.js'))) {
           config.tailwindConfig = 'tailwind.config.js';
+        } else if (fs.existsSync(path.join(projectRoot, 'tailwind.config.cjs'))) {
+          config.tailwindConfig = 'tailwind.config.cjs';
         } else if (fs.existsSync(path.join(projectRoot, 'tailwind.config.mjs'))) {
           config.tailwindConfig = 'tailwind.config.mjs';
         }


### PR DESCRIPTION
## Summary
- remove the unconditional creation of components.json during init
- generate the New York shadcn schema only when the shadcn MCP server is enabled
- clarify the init logs to reflect the conditional generation behaviour

## Testing
- node bin/bmad-invisible init --assistant=codex (skipped shadcn)
- node bin/bmad-invisible init --assistant=codex (enabled shadcn)


------
https://chatgpt.com/codex/tasks/task_e_68dfabcc4c9c83268cda775d671de4cf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Only create shadcn components.json when the MCP server is enabled; explicit skip message when disabled.
  * Added prereq validation that warns if Next.js/React or Tailwind CSS are missing.
  * Added registries configuration block and clearer log messages when defaults are overridden.

* **Refactor**
  * Default preset changed to "New York" and configuration is now auto-detected (config/CSS paths, RSC/TSX usage).
  * Preserve existing shadcn configuration if components.json already exists; improved success/warning messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->