### PR TITLE
Add GLM provider support and configurable Anthropic endpoint

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -1,6 +1,6 @@
 /**
  * LLM Client Integration
- * Supports Claude (Anthropic), GPT (OpenAI), and Gemini (Google)
+ * Supports Claude (Anthropic), GLM, GPT (OpenAI), and Gemini (Google)
  */
 
 const https = require('node:https');
@@ -309,19 +309,18 @@ class LLMClient {
   }
 
   getAnthropicHeaders() {
-    const headers = {
+    if (this.provider === 'glm') {
+      const authToken = process.env.ANTHROPIC_AUTH_TOKEN || process.env.GLM_API_KEY || this.apiKey;
+      return {
+        Authorization: `Bearer ${authToken}`,
+        'anthropic-version': '2023-06-01',
+      };
+    }
+
+    return {
       'x-api-key': this.apiKey,
       'anthropic-version': '2023-06-01',
     };
-
-    if (this.provider === 'glm') {
-      const authToken = process.env.ANTHROPIC_AUTH_TOKEN || process.env.GLM_API_KEY || this.apiKey;
-      if (authToken) {
-        headers.Authorization = `Bearer ${authToken}`;
-      }
-    }
-
-    return headers;
   }
 
   getAnthropicRequestTarget(pathSuffix) {

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -35,7 +35,7 @@ describe('LLMClient', () => {
     process.env.ANTHROPIC_AUTH_TOKEN = 'glm-auth';
     process.env.ANTHROPIC_BASE_URL = 'https://example.com/api/anthropic';
 
-    const client = new LLMClient({ provider: 'glm', model: undefined });
+    const client = new LLMClient({ provider: 'glm' });
     const requestSpy = jest
       .spyOn(client, 'makeRequest')
       .mockResolvedValue({ content: [{ text: 'hello' }] });
@@ -52,12 +52,129 @@ describe('LLMClient', () => {
       'POST',
       expect.objectContaining({ model: 'glm-4.6' }),
       expect.objectContaining({
-        'x-api-key': 'glm-key',
         Authorization: 'Bearer glm-auth',
         'anthropic-version': '2023-06-01',
       }),
       undefined,
     );
+
+    // Verify x-api-key is NOT sent for GLM
+    const headers = requestSpy.mock.calls[0][4];
+    expect(headers['x-api-key']).toBeUndefined();
+
+    requestSpy.mockRestore();
+  });
+
+  it('uses only x-api-key for claude provider (not Authorization)', async () => {
+    process.env.ANTHROPIC_API_KEY = 'claude-key';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'should-not-be-used';
+
+    const client = new LLMClient({ provider: 'claude' });
+    const requestSpy = jest
+      .spyOn(client, 'makeRequest')
+      .mockResolvedValue({ content: [{ text: 'response' }] });
+
+    await client.chat([{ role: 'user', content: 'test' }]);
+
+    const headers = requestSpy.mock.calls[0][4];
+    expect(headers['x-api-key']).toBe('claude-key');
+    expect(headers['Authorization']).toBeUndefined();
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+
+    requestSpy.mockRestore();
+  });
+
+  it('uses custom base URL for claude provider', async () => {
+    process.env.ANTHROPIC_API_KEY = 'claude-key';
+    process.env.ANTHROPIC_BASE_URL = 'https://custom.anthropic.com';
+
+    const client = new LLMClient({ provider: 'claude' });
+    const requestSpy = jest
+      .spyOn(client, 'makeRequest')
+      .mockResolvedValue({ content: [{ text: 'response' }] });
+
+    await client.chat([{ role: 'user', content: 'test' }]);
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      'custom.anthropic.com',
+      '/v1/messages',
+      'POST',
+      expect.any(Object),
+      expect.any(Object),
+      undefined,
+    );
+
+    requestSpy.mockRestore();
+  });
+
+  it('handles base URL with path prefix', async () => {
+    process.env.ANTHROPIC_API_KEY = 'key';
+    process.env.ANTHROPIC_BASE_URL = 'https://api.example.com/anthropic/v2';
+
+    const client = new LLMClient({ provider: 'claude' });
+    const requestSpy = jest
+      .spyOn(client, 'makeRequest')
+      .mockResolvedValue({ content: [{ text: 'response' }] });
+
+    await client.chat([{ role: 'user', content: 'test' }]);
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      'api.example.com',
+      '/anthropic/v2/v1/messages',
+      'POST',
+      expect.any(Object),
+      expect.any(Object),
+      undefined,
+    );
+
+    requestSpy.mockRestore();
+  });
+
+  it('handles base URL with trailing slash', async () => {
+    process.env.ANTHROPIC_API_KEY = 'key';
+    process.env.ANTHROPIC_BASE_URL = 'https://api.example.com/';
+
+    const client = new LLMClient({ provider: 'claude' });
+    const requestSpy = jest
+      .spyOn(client, 'makeRequest')
+      .mockResolvedValue({ content: [{ text: 'response' }] });
+
+    await client.chat([{ role: 'user', content: 'test' }]);
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      'api.example.com',
+      '/v1/messages',
+      'POST',
+      expect.any(Object),
+      expect.any(Object),
+      undefined,
+    );
+
+    requestSpy.mockRestore();
+  });
+
+  it('throws error for invalid base URL', () => {
+    process.env.ANTHROPIC_API_KEY = 'key';
+    process.env.ANTHROPIC_BASE_URL = 'not-a-valid-url';
+
+    const client = new LLMClient({ provider: 'claude' });
+
+    expect(() => client.getAnthropicRequestTarget('/v1/messages')).toThrow('Invalid ANTHROPIC_BASE_URL');
+  });
+
+  it('uses GLM_API_KEY when ANTHROPIC_AUTH_TOKEN is not set for GLM', async () => {
+    process.env.GLM_API_KEY = 'glm-only-key';
+
+    const client = new LLMClient({ provider: 'glm' });
+    const requestSpy = jest
+      .spyOn(client, 'makeRequest')
+      .mockResolvedValue({ content: [{ text: 'response' }] });
+
+    await client.chat([{ role: 'user', content: 'test' }]);
+
+    const headers = requestSpy.mock.calls[0][4];
+    expect(headers['Authorization']).toBe('Bearer glm-only-key');
+    expect(headers['x-api-key']).toBeUndefined();
 
     requestSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- add GLM provider handling that reads GLM/Anthropic tokens and sends the expected headers
- allow configuring the Anthropic host/path via ANTHROPIC_BASE_URL while keeping existing providers unchanged
- cover the new provider path and missing-credential scenarios with unit tests

## Testing
- npm test -- llm-client

------
https://chatgpt.com/codex/tasks/task_e_68dfb25c34c88326972e6b251b709469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GLM provider support with default model selection and routing through the Anthropic-compatible chat flow.
  - Support for configurable Anthropic base URL (including custom host, path prefixes, trailing slashes) and optional port.
  - Expanded environment variable handling for credentials, including GLM_API_KEY and Anthropic tokens, with clearer errors when missing.

- Tests
  - Added comprehensive coverage for GLM and Claude providers: credential resolution, base URL parsing/validation, header composition, and request targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->