### PR TITLE
Fix GLM chat route

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -362,14 +362,6 @@ class LLMClient {
   }
 
   getAnthropicHeaders() {
-    if (this.provider === 'glm') {
-      const authToken = process.env.ANTHROPIC_AUTH_TOKEN || process.env.GLM_API_KEY || this.apiKey;
-      return {
-        Authorization: `Bearer ${authToken}`,
-        'anthropic-version': '2023-06-01',
-      };
-    }
-
     return {
       'x-api-key': this.apiKey,
       'anthropic-version': '2023-06-01',

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -92,4 +92,52 @@ describe('LLMClient', () => {
       expect.any(Function),
     );
   });
+
+  it('routes GLM requests to open.bigmodel.cn not Anthropic', async () => {
+    process.env.GLM_API_KEY = 'glm-test-key';
+
+    const responseListeners = {};
+    const mockResponse = {
+      statusCode: 200,
+      on: jest.fn((event, handler) => {
+        responseListeners[event] = handler;
+      }),
+    };
+
+    https.request.mockImplementation((options, callback) => {
+      callback(mockResponse);
+
+      if (responseListeners.data) {
+        responseListeners.data(
+          JSON.stringify({
+            choices: [{ message: { content: 'GLM response' } }],
+          }),
+        );
+      }
+      if (responseListeners.end) {
+        responseListeners.end();
+      }
+
+      return {
+        on: jest.fn(),
+        write: jest.fn(),
+        end: jest.fn(),
+      };
+    });
+
+    const client = new LLMClient({ provider: 'glm' });
+    const result = await client.chat([{ role: 'user', content: 'Hello' }], {
+      temperature: 0.5,
+      maxTokens: 100,
+    });
+
+    expect(result).toBe('GLM response');
+    expect(https.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: 'open.bigmodel.cn',
+        path: '/api/paas/v4/chat/completions',
+      }),
+      expect.any(Function),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- ensure the GLM provider routes through the GLM-specific chat client instead of Anthropics

## Testing
- npm test -- --runTestsByPath test/llm-client.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dfdf80f5ac832695b2666c348ed685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * GLM chat handling separated from Claude/Anthropic so each provider follows its own routing and header flow; no changes to public APIs and no user action required.
* **Tests**
  * Added a test validating GLM requests are routed to the correct provider endpoint and produce expected responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->