### PR TITLE
Update launch scripts to use Agilai MCP config

### DIFF
--- a/bin/agilai-claude
+++ b/bin/agilai-claude
@@ -15,12 +15,23 @@ const { buildAssistantSpawnEnv } = require('../common/utils/assistant-env');
 // Get paths
 const rootDir = path.join(__dirname, '..');
 runIntegrityPreflight(rootDir, { silentOnMatch: true });
-const mcpConfigPath = path.join(rootDir, 'mcp', 'bmad-config.json');
+const mcpConfigDir = path.join(rootDir, 'mcp');
+const newMcpConfigPath = path.join(mcpConfigDir, 'agilai-config.json');
+const legacyMcpConfigPath = path.join(mcpConfigDir, 'bmad-config.json');
+let mcpConfigPath = newMcpConfigPath;
+let usingLegacyMcpConfig = false;
 const orchestratorPath = path.join(rootDir, 'agents', 'invisible-orchestrator.md');
 
 // Check if files exist
 if (!fs.existsSync(mcpConfigPath)) {
-  console.error('Error: MCP config not found. Run: npm run build:mcp');
+  if (fs.existsSync(legacyMcpConfigPath)) {
+    usingLegacyMcpConfig = true;
+    mcpConfigPath = legacyMcpConfigPath;
+  }
+}
+
+if (!fs.existsSync(mcpConfigPath)) {
+  console.error('Error: MCP config not found. Expected mcp/agilai-config.json. Run: npm run build:mcp');
   process.exit(1);
 }
 
@@ -72,8 +83,12 @@ async function main() {
     claudeArgs.push(...userArgs);
   }
 
+  if (usingLegacyMcpConfig) {
+    console.warn('⚠️  Using legacy MCP config mcp/bmad-config.json. Please migrate to mcp/agilai-config.json.');
+  }
+
   console.log('🎯 Starting Agilai Orchestrator...');
-  console.log('📡 MCP Server: bmad-invisible-orchestrator');
+  console.log('📡 MCP Server: agilai-invisible-orchestrator');
   console.log('🤖 Agent: Agilai Orchestrator');
   console.log('💬 Type your project idea to begin!\n');
 

--- a/bin/agilai-codex
+++ b/bin/agilai-codex
@@ -15,12 +15,23 @@ const { buildAssistantSpawnEnv } = require('../common/utils/assistant-env');
 // Get paths
 const rootDir = path.join(__dirname, '..');
 runIntegrityPreflight(rootDir, { silentOnMatch: true });
-const mcpConfigPath = path.join(rootDir, 'mcp', 'bmad-config.json');
+const mcpConfigDir = path.join(rootDir, 'mcp');
+const newMcpConfigPath = path.join(mcpConfigDir, 'agilai-config.json');
+const legacyMcpConfigPath = path.join(mcpConfigDir, 'bmad-config.json');
+let mcpConfigPath = newMcpConfigPath;
+let usingLegacyMcpConfig = false;
 const orchestratorPath = path.join(rootDir, 'agents', 'invisible-orchestrator.md');
 
 // Check if files exist
 if (!fs.existsSync(mcpConfigPath)) {
-  console.error('Error: MCP config not found. Run: npm run build:mcp');
+  if (fs.existsSync(legacyMcpConfigPath)) {
+    usingLegacyMcpConfig = true;
+    mcpConfigPath = legacyMcpConfigPath;
+  }
+}
+
+if (!fs.existsSync(mcpConfigPath)) {
+  console.error('Error: MCP config not found. Expected mcp/agilai-config.json. Run: npm run build:mcp');
   process.exit(1);
 }
 
@@ -76,9 +87,13 @@ async function main() {
     ...userArgs,
   ];
 
+  if (usingLegacyMcpConfig) {
+    console.warn('⚠️  Using legacy MCP config mcp/bmad-config.json. Please migrate to mcp/agilai-config.json.');
+  }
+
   console.log('🎯 Starting Agilai Orchestrator with Codex...');
 
-  console.log('📡 MCP Server: bmad-invisible-orchestrator');
+  console.log('📡 MCP Server: agilai-invisible-orchestrator');
   console.log('🤖 Agent: Agilai Orchestrator');
   console.log('💬 Type your project idea to begin!\n');
 

--- a/mcp/agilai-config.json
+++ b/mcp/agilai-config.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "agilai-invisible-orchestrator": {
+      "command": "node",
+      "args": ["dist/mcp/mcp/server.js"]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-chrome-devtools"]
+    },
+    "shadcn": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-shadcn"]
+    },
+    "gitmcp": {
+      "command": "npx",
+      "args": ["-y", "gitmcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- update the Agilai Claude and Codex launchers to load the new mcp/agilai-config.json file, falling back to the legacy name with a migration warning
- refresh the user-facing MCP server identifier in both scripts to the agilai-* naming
- add the new agilai MCP configuration to the repository under mcp/

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03107ba9483269254dc16152a9496