### PR TITLE
Rename hidden CLI assets to agilai

### DIFF
--- a/.dev/test/brownfield-analyzer.previous-state.test.js
+++ b/.dev/test/brownfield-analyzer.previous-state.test.js
@@ -20,7 +20,7 @@ describe('BrownfieldAnalyzer.detectPreviousState', () => {
 
   it('surfaces updatedAt timestamps when present in stored state', async () => {
     const analyzer = new BrownfieldAnalyzer(tempDir);
-    const stateDir = path.join(tempDir, '.bmad-invisible');
+    const stateDir = path.join(tempDir, '.agilai');
     const stateFile = path.join(stateDir, 'state.json');
     const storedState = {
       phase: 'analyst',
@@ -39,7 +39,7 @@ describe('BrownfieldAnalyzer.detectPreviousState', () => {
 
   it('falls back to legacy lastUpdated timestamps when updatedAt is absent', async () => {
     const analyzer = new BrownfieldAnalyzer(tempDir);
-    const stateDir = path.join(tempDir, '.bmad-invisible');
+    const stateDir = path.join(tempDir, '.agilai');
     const stateFile = path.join(stateDir, 'state.json');
     const storedState = {
       phase: 'strategist',

--- a/.dev/test/lane-selector.test.js
+++ b/.dev/test/lane-selector.test.js
@@ -384,7 +384,7 @@ describe('Lane decision logging', () => {
 
       await logDecision(tempDir, decision, 'Test message');
 
-      const logPath = path.join(tempDir, '.bmad-invisible', 'decisions.jsonl');
+      const logPath = path.join(tempDir, '.agilai', 'decisions.jsonl');
       const content = await fs.readFile(logPath, 'utf8');
       const lines = content.trim().split('\n');
       const entry = JSON.parse(lines.at(-1));

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ Thumbs.db
 .windsurf/
 .trae/
 .bmad*/
-!.bmad-invisible/
+!.agilai/
 .cursor/
 
 # AI assistant files

--- a/.npmignore
+++ b/.npmignore
@@ -11,7 +11,7 @@
 .github/
 .husky/
 .vscode/
-.bmad-invisible/
+.agilai/
 .claude/
 
 # Development documentation

--- a/bin/agilai
+++ b/bin/agilai
@@ -891,11 +891,11 @@ const commands = {
       console.log('✅ Created package.json');
     }
 
-    // Create .bmad-invisible directory
-    const bmadDir = path.join(projectRoot, '.bmad-invisible');
-    if (!fs.existsSync(bmadDir)) {
-      fs.mkdirSync(bmadDir, { recursive: true });
-      console.log('✅ Created .bmad-invisible directory');
+    // Create .agilai directory
+    const agilaiDir = path.join(projectRoot, '.agilai');
+    if (!fs.existsSync(agilaiDir)) {
+      fs.mkdirSync(agilaiDir, { recursive: true });
+      console.log('✅ Created .agilai directory');
     }
 
     // Create .claude directory for MCP config
@@ -923,10 +923,10 @@ const commands = {
       }
     }
 
-    const orchestratorKey = 'bmad-invisible-orchestrator';
+    const orchestratorKey = 'agilai-orchestrator';
     const orchestratorConfig = {
       command: 'node',
-      args: ['${workspaceFolder}/node_modules/bmad-invisible/dist/mcp/mcp/server.js'],
+      args: ['${workspaceFolder}/node_modules/agilai/dist/mcp/mcp/server.js'],
       disabled: false,
     };
 
@@ -1032,12 +1032,12 @@ const commands = {
     packageJson.scripts = packageJson.scripts || {};
 
     const scriptsToAdd = {
-      bmad: 'bmad-invisible start',
-      codex: 'bmad-invisible codex',
-      'bmad:codex': 'bmad-invisible codex',
-      'bmad:claude': 'bmad-invisible chat',
-      'bmad:opencode': 'bmad-invisible opencode',
-      'bmad:build': 'bmad-invisible build',
+      agilai: 'agilai start',
+      codex: 'agilai codex',
+      'agilai:codex': 'agilai codex',
+      'agilai:claude': 'agilai chat',
+      'agilai:opencode': 'agilai opencode',
+      'agilai:build': 'agilai build',
     };
 
     let scriptsAdded = false;
@@ -1053,17 +1053,17 @@ const commands = {
       console.log('✅ Added npm scripts to package.json');
     }
 
-    // Add bmad-invisible as a dependency
+    // Add agilai as a dependency
     const desiredDependencyVersion = `^${currentVersion}`;
     const existingDependencyVersion =
-      packageJson.dependencies && packageJson.dependencies['bmad-invisible'];
+      packageJson.dependencies && packageJson.dependencies.agilai;
     const needsDependencyUpdate = existingDependencyVersion !== desiredDependencyVersion;
 
     if (needsDependencyUpdate) {
       packageJson.dependencies = packageJson.dependencies || {};
-      packageJson.dependencies['bmad-invisible'] = desiredDependencyVersion;
+      packageJson.dependencies.agilai = desiredDependencyVersion;
       fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n');
-      console.log(`✅ Ensured bmad-invisible@${desiredDependencyVersion} is listed in dependencies`);
+      console.log(`✅ Ensured agilai@${desiredDependencyVersion} is listed in dependencies`);
     }
 
     // Only create components.json if shadcn MCP server is enabled
@@ -1212,7 +1212,7 @@ Next steps:
      https://platform.openai.com/docs/guides/codex
 
   3. Start chatting:
-     npm run codex
+     npm run agilai:codex
 
 
 For detailed documentation, visit:
@@ -1223,10 +1223,10 @@ For detailed documentation, visit:
   codex: async () => {
     consumeLlmOptionsFromArgs();
 
-    const localInstall = path.join(process.cwd(), 'node_modules', 'bmad-invisible');
+    const localInstall = path.join(process.cwd(), 'node_modules', 'agilai');
     const codexScript = fs.existsSync(localInstall)
-      ? path.join(localInstall, 'bin', 'bmad-codex')
-      : path.join(__dirname, 'bmad-codex');
+      ? path.join(localInstall, 'bin', 'agilai-codex')
+      : path.join(__dirname, 'agilai-codex');
 
     if (!fs.existsSync(codexScript)) {
       console.error('❌ Agilai not found. Please run "npm install" first.');
@@ -1253,11 +1253,11 @@ For detailed documentation, visit:
   chat: async () => {
     consumeLlmOptionsFromArgs();
 
-    // Check if bmad-invisible is installed locally first
-    const localInstall = path.join(process.cwd(), 'node_modules', 'bmad-invisible');
+    // Check if agilai is installed locally first
+    const localInstall = path.join(process.cwd(), 'node_modules', 'agilai');
     const chatScript = fs.existsSync(localInstall)
-      ? path.join(localInstall, 'bin', 'bmad-claude')
-      : path.join(__dirname, 'bmad-claude');
+      ? path.join(localInstall, 'bin', 'agilai-claude')
+      : path.join(__dirname, 'agilai-claude');
 
     if (!fs.existsSync(chatScript)) {
       console.error('❌ Agilai not found. Please run "npm install" first.');
@@ -1317,7 +1317,7 @@ For detailed documentation, visit:
   install: async () => {
     console.log('📦 Installing Agilai globally...\n');
 
-    const child = spawn('npm', ['install', '-g', 'bmad-invisible'], {
+    const child = spawn('npm', ['install', '-g', 'agilai'], {
       stdio: 'inherit',
       shell: true,
     });
@@ -1335,7 +1335,7 @@ For detailed documentation, visit:
     console.log('🔨 Building MCP server...\n');
 
     // Check if running from local install or global/npx
-    const localInstall = path.join(process.cwd(), 'node_modules', 'bmad-invisible');
+    const localInstall = path.join(process.cwd(), 'node_modules', 'agilai');
     const rootDir = fs.existsSync(localInstall) ? localInstall : path.join(__dirname, '..');
 
     // The MCP server is already pre-built in dist/, but we'll check TypeScript is available

--- a/bin/agilai-claude
+++ b/bin/agilai-claude
@@ -73,7 +73,7 @@ async function main() {
   }
 
   console.log('🎯 Starting Agilai Orchestrator...');
-  console.log('📡 MCP Server: bmad-invisible-orchestrator');
+  console.log('📡 MCP Server: agilai-orchestrator');
   console.log('🤖 Agent: Agilai Orchestrator');
   console.log('💬 Type your project idea to begin!\n');
 

--- a/bin/agilai-codex
+++ b/bin/agilai-codex
@@ -78,7 +78,7 @@ async function main() {
 
   console.log('🎯 Starting Agilai Orchestrator with Codex...');
 
-  console.log('📡 MCP Server: bmad-invisible-orchestrator');
+  console.log('📡 MCP Server: agilai-orchestrator');
   console.log('🤖 Agent: Agilai Orchestrator');
   console.log('💬 Type your project idea to begin!\n');
 

--- a/common/utils/cli-provisioning.js
+++ b/common/utils/cli-provisioning.js
@@ -6,7 +6,7 @@ const { spawnSync, spawn } = require('node:child_process');
 const readline = require('node:readline');
 
 function ensureStateDir(rootDir) {
-  const stateDir = path.join(rootDir, '.bmad-invisible');
+  const stateDir = path.join(rootDir, '.agilai');
 
   // Try creating in rootDir first
   if (!fs.existsSync(stateDir)) {
@@ -16,7 +16,7 @@ function ensureStateDir(rootDir) {
     } catch (error) {
       // If rootDir is read-only (e.g., global npm install, CI artifact), fall back to user home
       if (error.code === 'EACCES' || error.code === 'EROFS' || error.code === 'EPERM') {
-        const fallbackDir = path.join(os.homedir(), '.bmad-invisible');
+        const fallbackDir = path.join(os.homedir(), '.agilai');
         if (!fs.existsSync(fallbackDir)) {
           try {
             fs.mkdirSync(fallbackDir, { recursive: true });

--- a/common/utils/integrity.js
+++ b/common/utils/integrity.js
@@ -28,7 +28,7 @@ const CRITICAL_PATHS = [
 
 const BASELINE_FILENAME = 'critical-hashes.json';
 
-const getBaselinePath = (rootDir) => path.join(rootDir, '.bmad-invisible', BASELINE_FILENAME);
+const getBaselinePath = (rootDir) => path.join(rootDir, '.agilai', BASELINE_FILENAME);
 
 const computeFileHash = (filePath) => {
   const hash = crypto.createHash('sha256');

--- a/dist/mcp/lib/codex/config-manager.js
+++ b/dist/mcp/lib/codex/config-manager.js
@@ -7,7 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 const DEFAULT_MODEL = 'GPT-5-Codex';
 const DEFAULT_MANUAL_APPROVAL = false;
-const SERVER_NAME = 'bmad-mcp';
+const SERVER_NAME = 'agilai-mcp';
 const DEFAULT_SERVERS = [
   {
     name: SERVER_NAME,
@@ -15,7 +15,7 @@ const DEFAULT_SERVERS = [
     description: 'Agilai MCP server for orchestrating BMAD agents.',
     transport: 'stdio',
     command: 'npx',
-    args: ['bmad-invisible', 'mcp'],
+    args: ['agilai', 'mcp'],
     autoStart: true,
     autoApprove: true,
   },

--- a/dist/mcp/lib/codex/config-manager.ts
+++ b/dist/mcp/lib/codex/config-manager.ts
@@ -16,7 +16,7 @@ type TomlTable = Record<string, any>;
 
 const DEFAULT_MODEL = 'GPT-5-Codex';
 const DEFAULT_MANUAL_APPROVAL = false;
-const SERVER_NAME = 'bmad-mcp';
+const SERVER_NAME = 'agilai-mcp';
 
 const DEFAULT_SERVERS: ReadonlyArray<TomlTable> = [
   {
@@ -25,7 +25,7 @@ const DEFAULT_SERVERS: ReadonlyArray<TomlTable> = [
     description: 'Agilai MCP server for orchestrating BMAD agents.',
     transport: 'stdio',
     command: 'npx',
-    args: ['bmad-invisible', 'mcp'],
+    args: ['agilai', 'mcp'],
     autoStart: true,
     autoApprove: true,
   },

--- a/docs/DUAL_LANE_ORCHESTRATION.md
+++ b/docs/DUAL_LANE_ORCHESTRATION.md
@@ -290,7 +290,7 @@ my-project/
 │   └── stories/                # Development stories
 │       ├── story-1-login.md
 │       └── story-2-signup.md
-└── .bmad-invisible/
+└── .agilai/
     ├── state.json              # Project state
     ├── conversation.json       # Chat history
     ├── deliverables.json       # Generated artifacts
@@ -299,7 +299,7 @@ my-project/
 
 ### Decision Logging
 
-Every lane decision is logged in `.bmad-invisible/decisions.jsonl`:
+Every lane decision is logged in `.agilai/decisions.jsonl`:
 
 ```jsonl
 {"timestamp":"2agilai25-1agilai-agilai1T2agilai:agilaiagilai:agilaiagilaiZ","userMessage":"Fix typo in README","lane":"quick","confidence":agilai.92,"rationale":"Quick lane: quick fix keywords, short message","scores":{"quick":7,"complex":1}}
@@ -403,7 +403,7 @@ The lane selector has been tuned with 36+ test cases covering edge cases, mixed 
 **Check decision log:**
 
 ```bash
-cat .bmad-invisible/decisions.jsonl | tail -1 | jq
+cat .agilai/decisions.jsonl | tail -1 | jq
 ```
 
 **Manual override in code:**

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,7 +24,7 @@ your-project/
 │   └── qa/
 │       └── assessments/
 │           └── risk-assessment.md   # Test strategy
-└── .bmad-invisible/
+└── .agilai/
     ├── state.json                   # Current phase and project state
     ├── conversation.json            # Full conversation history
     └── deliverables.json            # Generated content references
@@ -304,7 +304,7 @@ Orchestrator: [Scans codebase]
 
 ### How does state tracking work?
 
-The orchestrator maintains complete project state in `.bmad-invisible/`:
+The orchestrator maintains complete project state in `.agilai/`:
 
 #### `state.json` - Current Project State
 
@@ -501,7 +501,7 @@ ls -la dist/mcp/mcp/server.js
 
 ```bash
 # Reset state (backs up old state)
-rm .bmad-invisible/state.json
+rm .agilai/state.json
 npm run bmad
 # Orchestrator will start fresh
 ```

--- a/docs/IMPLEMENTATION_COMPLETE.md
+++ b/docs/IMPLEMENTATION_COMPLETE.md
@@ -21,7 +21,7 @@ Successfully implemented a **fully functional MCP-based invisible orchestrator**
    - Phase transition history
    - Requirements and decisions storage
    - Deliverables tracking
-   - JSON persistence to `.bmad-invisible/`
+   - JSON persistence to `.agilai/`
 
 3. **BMAD Integration Bridge** (`lib/bmad-bridge.js`) - **343 lines**
    - Agent loading and persona extraction
@@ -219,7 +219,7 @@ npm test
 ✅ **Integrates with existing BMAD CLI** - npm run bmad (with `npm run bmad:claude` / `npm run bmad:codex` for specific front-ends)
 ✅ **Generates real deliverables** - docs/ folder populated
 ✅ **Maintains invisible UX** - No methodology jargon
-✅ **Persists state** - .bmad-invisible/ folder
+✅ **Persists state** - .agilai/ folder
 ✅ **Uses MCP protocol** - Native Claude integration
 ✅ **Validates with user** - Checkpoints at phase transitions
 ✅ **Production code quality** - Error handling, logging, types

--- a/docs/STORY_CONTEXT.md
+++ b/docs/STORY_CONTEXT.md
@@ -57,7 +57,7 @@ This approach keeps the workflow silent for end users while achieving parity wit
     "arguments": { "validateStoryContext": true }
   }
   ```
-- When enabled, transitioning into the developer phase automatically calls `run_story_context_validation`. Any missing persona fragments, acceptance criteria, or definition of done entries will block the transition and capture a record in `.bmad-invisible/reviews.json` via `ProjectState.recordReviewOutcome()`.
+- When enabled, transitioning into the developer phase automatically calls `run_story_context_validation`. Any missing persona fragments, acceptance criteria, or definition of done entries will block the transition and capture a record in `.agilai/reviews.json` via `ProjectState.recordReviewOutcome()`.
 - Operators can also run the checkpoint manually to inspect the enriched packet:
   ```json
   {

--- a/docs/mcp-examples.md
+++ b/docs/mcp-examples.md
@@ -302,7 +302,7 @@ npm run mcp:audit
 # File Permissions:
 #   ⚠ Warning: Master key file has permissions 644
 #     Expected: 6agilaiagilai
-#     Fix: chmod 6agilaiagilai ~/.bmad-invisible/secure/.master.key
+#     Fix: chmod 6agilaiagilai ~/.agilai/secure/.master.key
 #
 # Recommendations for 'prod' profile:
 #   🔒 Production should use secure credential storage

--- a/docs/review-checkpoints.md
+++ b/docs/review-checkpoints.md
@@ -25,7 +25,7 @@ The invisible orchestrator now enforces three governance gates that run on a fre
    }
    ```
 3. The MCP server instantiates a dedicated `BMADBridge` wired to the `review` lane. Deliverables from the source phase plus the overall project snapshot are passed as context.
-4. The reviewer agent responds with JSON. Results are stored automatically via `ProjectState.recordReviewOutcome()` in `.bmad-invisible/reviews.json` for auditability.
+4. The reviewer agent responds with JSON. Results are stored automatically via `ProjectState.recordReviewOutcome()` in `.agilai/reviews.json` for auditability.
 5. If the reviewer returns `revise` or `block`, stay in the current phase, address the findings with the user, and re-run the checkpoint. When story-context validation is enabled, a `block` result prevents the developer transition automatically.
 
 ## Data Capture


### PR DESCRIPTION
## Summary
- update the CLI scaffolding to create and cache state in `.agilai` instead of `.bmad-invisible`
- ensure generated npm scripts and dependency bootstrap reference the `agilai` package and executables
- refresh launcher messaging and MCP defaults to use the new `agilai-*` server identifiers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e03109356c8326a9616b9031286849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rebranded all CLI commands and scripts from “bmad-invisible” to “agilai.”
  * Updated orchestrator labels and startup logs to “agilai-orchestrator.”
  * Revised install and usage guidance to reference agilai commands.

* **Refactor**
  * Switched default paths and server entry points to agilai equivalents.
  * Moved state/cache directory to ~/.agilai and updated baseline file location accordingly.

* **Documentation**
  * Updated user-facing prompts and messages to reflect the agilai naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->