### PR TITLE
docs: update CLI references to agilai

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -148,7 +148,7 @@ npm install
 #### 2. Start conversation
 
 ```bash
-npm run bmad
+npm run agilai
 ```
 
 #### 3. Tell the orchestrator about existing work
@@ -215,7 +215,7 @@ The orchestrator intelligently handles existing docs:
 ```bash
 # Come back days/weeks later
 cd your-project
-npm run bmad
+npm run agilai
 
 # Orchestrator automatically loads state
 Orchestrator: "Welcome back! We were working on the team todo app.
@@ -502,7 +502,7 @@ ls -la dist/mcp/mcp/server.js
 ```bash
 # Reset state (backs up old state)
 rm .agilai/state.json
-npm run bmad
+npm run agilai
 # Orchestrator will start fresh
 ```
 

--- a/docs/IMPLEMENTATION_COMPLETE.md
+++ b/docs/IMPLEMENTATION_COMPLETE.md
@@ -124,7 +124,7 @@ npm install
 npm run build:mcp
 
 # Start conversational interface
-npm run bmad
+npm run agilai
 
 # Talk naturally
 "Help me build a task management app for my family"
@@ -216,7 +216,7 @@ npm test
 ## Success Criteria
 
 ✅ **Works without API keys** - Uses Claude Pro subscription
-✅ **Integrates with existing BMAD CLI** - npm run bmad (with `npm run bmad:claude` / `npm run bmad:codex` for specific front-ends)
+✅ **Integrates with the Agilai CLI** - npm run agilai (with `npm run agilai:claude` / `npm run agilai:codex` for specific front-ends)
 ✅ **Generates real deliverables** - docs/ folder populated
 ✅ **Maintains invisible UX** - No methodology jargon
 ✅ **Persists state** - .agilai/ folder
@@ -235,10 +235,10 @@ npm test
 ## Usage Command
 
 ```bash
-npm run bmad
+npm run agilai
 # Or pick a specific front-end:
-# npm run bmad:claude
-# npm run bmad:codex
+# npm run agilai:claude
+# npm run agilai:codex
 ```
 
 That's literally it. Just run one command and start talking about your project!

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,11 +39,11 @@ Enable GLM (ZhipuAI) for the orchestrator:
 
 ```bash
 # Use GLM via flag
-npm run bmad -- --glm
+npm run agilai -- --glm
 npx agilai start --glm
 
 # Explicit provider specification
-npm run bmad -- --llm-provider=glm
+npm run agilai -- --llm-provider=glm
 npx agilai start --llm-provider=glm
 ```
 
@@ -72,19 +72,21 @@ GLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4/chat/completions
 
 When GLM mode is active, variables are resolved in this order:
 
-| Variable               | Priority | Description                              |
-| ---------------------- | -------- | ---------------------------------------- |
-| `BMAD_GLM_BASE_URL`    | 1        | GLM API base URL (BMAD-specific)         |
-| `GLM_BASE_URL`         | 2        | GLM API base URL (standard)              |
-| `ANTHROPIC_BASE_URL`   | 3        | Anthropic base URL (fallback)            |
-| `BMAD_GLM_AUTH_TOKEN`  | 1        | GLM authentication token (BMAD-specific) |
-| `GLM_AUTH_TOKEN`       | 2        | GLM authentication token (standard)      |
-| `ANTHROPIC_AUTH_TOKEN` | 3        | Anthropic auth token (fallback)          |
-| `BMAD_GLM_API_KEY`     | 1        | GLM API key (BMAD-specific)              |
-| `GLM_API_KEY`          | 2        | GLM API key (standard)                   |
-| `ANTHROPIC_API_KEY`    | 3        | Anthropic API key (fallback)             |
+| Variable               | Priority | Description                            |
+| ---------------------- | -------- | -------------------------------------- |
+| `BMAD_GLM_BASE_URL`    | 1        | GLM API base URL (legacy BMAD name)    |
+| `GLM_BASE_URL`         | 2        | GLM API base URL (standard)            |
+| `ANTHROPIC_BASE_URL`   | 3        | Anthropic base URL (fallback)          |
+| `BMAD_GLM_AUTH_TOKEN`  | 1        | GLM authentication token (legacy name) |
+| `GLM_AUTH_TOKEN`       | 2        | GLM authentication token (standard)    |
+| `ANTHROPIC_AUTH_TOKEN` | 3        | Anthropic auth token (fallback)        |
+| `BMAD_GLM_API_KEY`     | 1        | GLM API key (legacy name)              |
+| `GLM_API_KEY`          | 2        | GLM API key (standard)                 |
+| `ANTHROPIC_API_KEY`    | 3        | Anthropic API key (fallback)           |
 
 **Note:** At least one of `*_BASE_URL` or `*_API_KEY` must be set when using GLM mode.
+
+> ℹ️ **Agilai naming update**: The runtime still reads the legacy `BMAD_*` environment variables for GLM routing. You can safely define `AGILAI_*` aliases in your own tooling, but keep exporting the `BMAD_*` names until the CLI adds first-class Agilai prefixes.
 
 #### Custom Endpoints
 
@@ -107,16 +109,21 @@ export BMAD_ASSISTANT_PROVIDER=glm
 export BMAD_GLM_BASE_URL=https://your-glm-endpoint.com
 export BMAD_GLM_API_KEY=your-api-key
 
-# Start BMAD with GLM routing
-npm run bmad:claude
+# Optional: mirror values for future Agilai-prefixed variables
+export AGILAI_ASSISTANT_PROVIDER="$BMAD_ASSISTANT_PROVIDER"
+export AGILAI_GLM_BASE_URL="$BMAD_GLM_BASE_URL"
+export AGILAI_GLM_API_KEY="$BMAD_GLM_API_KEY"
+
+# Start the Agilai orchestrator with GLM routing
+npm run agilai:claude
 # Output: 🌐 GLM mode active: routing Claude CLI through configured GLM endpoint.
 ```
 
 GLM routing works with all three assistant CLIs:
 
-- `npm run bmad:claude` - Routes Claude CLI through GLM
-- `npm run bmad:codex` - Routes Codex CLI through GLM
-- `npm run bmad:opencode` - Routes OpenCode CLI through GLM
+- `npm run agilai:claude` - Routes Claude CLI through GLM
+- `npm run agilai:codex` - Routes Codex CLI through GLM
+- `npm run agilai:opencode` - Routes OpenCode CLI through GLM
 
 ### Anthropic Provider (Default)
 
@@ -126,11 +133,11 @@ Using Anthropic's Claude (default behavior):
 
 ```bash
 # Use Anthropic (default)
-npm run bmad
-npm run bmad -- --anthropic
+npm run agilai
+npm run agilai -- --anthropic
 
 # Explicit provider
-npm run bmad -- --llm-provider=claude
+npm run agilai -- --llm-provider=claude
 ```
 
 #### Environment Variables
@@ -154,14 +161,14 @@ Switch providers anytime:
 
 ```bash
 # Start with GLM
-npm run bmad -- --glm
+npm run agilai -- --glm
 
 # Later, switch to Anthropic
-npm run bmad -- --anthropic
+npm run agilai -- --anthropic
 
 # Or change .env file
 echo "LLM_PROVIDER=claude" >> .env
-npm run bmad
+npm run agilai
 ```
 
 **Priority order:**
@@ -276,7 +283,7 @@ CODEX_APPROVED_OPERATIONS=generate_deliverable:prd,execute_quick_lane
 - `generate_deliverable:story` - Generate user stories
 - `execute_quick_lane` - Run Quick Lane workflow
 - `execute_complex_lane` - Run Complex Lane workflow
-- `transition_phase` - Move to next BMAD phase
+- `transition_phase` - Move to next Agilai phase
 
 ### Model Overrides
 
@@ -336,7 +343,7 @@ Agilai emits structured JSON logs to `stderr`:
   "ts": "2024-07-16T12:34:56.789Z",
   "level": "info",
   "msg": "lane_selection_completed",
-  "service": "bmad-codex",
+  "service": "agilai-codex",
   "component": "mcp-orchestrator",
   "operation": "execute_workflow",
   "lane": "quick",
@@ -472,7 +479,7 @@ Validate your configuration:
 npm run mcp:doctor
 
 # Test LLM provider connection
-npm run bmad -- --test
+npm run agilai -- --test
 
 # Audit security settings
 npm run mcp:audit
@@ -532,7 +539,7 @@ If environment variables aren't being read:
 
 If using the wrong provider:
 
-1. Check CLI flag: `npm run bmad -- --glm`
+1. Check CLI flag: `npm run agilai -- --glm`
 2. Verify `.env` contents: `cat .env | grep LLM_PROVIDER`
 3. Check priority: CLI flags override environment variables
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,7 +16,7 @@ This example shows the complete flow for starting a new app from scratch.
 ### Example: Family Chore Tracking App
 
 ````bash
-$ npm run bmad
+$ npm run agilai
 Which assistant should we launch? (Claude / Codex / Opencode): claude
 
 🎯 Starting Agilai Orchestrator...
@@ -577,12 +577,12 @@ Agilai maintains separate contexts for different projects:
 ```bash
 # Work on project A
 cd project-a
-npm run bmad
+npm run agilai
 # Context: Project A state
 
 # Switch to project B
 cd ../project-b
-npm run bmad
+npm run agilai
 # Context: Project B state (completely separate)
 ````
 
@@ -597,7 +597,7 @@ Each project has its own:
 Agilai remembers where you left off:
 
 ```bash
-$ npm run bmad
+$ npm run agilai
 
 Welcome back! Last time we were working on:
 - Story 1.2: Assign Tasks to Family Members

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -53,13 +53,13 @@ npm install
 
 
 # Start chatting (prompts for your choice)
-npm run bmad
+npm run agilai
 # Force GLM for the orchestrator (requires ZHIPUAI_API_KEY or GLM_API_KEY)
-# npm run bmad -- --glm
+# npm run agilai -- --glm
 # OR use explicit commands:
-# npm run bmad:claude    # respects --glm/--anthropic flags
-# npm run bmad:codex     # respects --glm/--anthropic flags
-# npm run bmad:opencode  # respects --glm/--anthropic flags
+# npm run agilai:claude    # respects --glm/--anthropic flags
+# npm run agilai:codex     # respects --glm/--anthropic flags
+# npm run agilai:opencode  # respects --glm/--anthropic flags
 
 ```
 
@@ -94,7 +94,7 @@ npm run build:mcp
 
 
 # Start conversation (prompts for choice)
-npm run bmad
+npm run agilai
 ```
 
 #### Choosing Your LLM Provider (GLM vs Anthropic)
@@ -215,10 +215,10 @@ AI: Found 23 TODOs across 8 files. Oldest is 3 months old.
 npx bmad-invisible@latest start # 🚀 One-command setup and launch (prompts for choice)
 npx bmad-invisible init         # Initialize in project
 npx bmad-invisible build        # Build MCP server
-npm run bmad                    # Start conversation (prompts for assistant choice)
-npm run bmad:claude             # Start Claude directly
-npm run bmad:codex              # Start Codex directly
-npm run bmad:opencode           # Start OpenCode directly
+npm run agilai                    # Start conversation (prompts for assistant choice)
+npm run agilai:claude             # Start Claude directly
+npm run agilai:codex              # Start Codex directly
+npm run agilai:opencode           # Start OpenCode directly
 # Append -- --glm (or -- --anthropic) to any npm script to swap providers
 
 npx bmad-invisible test         # Run tests
@@ -228,7 +228,7 @@ npx bmad-invisible help         # Show all commands
 
 ### Example Session
 
-Run `npm run bmad` and choose your assistant, or use direct commands (`npm run bmad:claude`, `npm run bmad:codex`, `npm run bmad:opencode`). You'll see an experience like this:
+Run `npm run agilai` and choose your assistant, or use direct commands (`npm run agilai:claude`, `npm run agilai:codex`, `npm run agilai:opencode`). You'll see an experience like this:
 
 ```
 🎯 Starting Agilai Orchestrator...

--- a/docs/guides/USAGE.md
+++ b/docs/guides/USAGE.md
@@ -259,7 +259,7 @@ This step is skipped automatically in non-interactive environments. See [`codex-
 
 ### Automatic CLI Provisioning
 
-The Agilai Codex (`bin/bmad-codex`) and Agilai Claude (`bin/bmad-claude`) launchers now validate that the Codex and Claude CLIs are installed **before** spawning the orchestrator session. If a binary is missing, the script will:
+The Agilai Codex (`bin/agilai-codex`) and Agilai Claude (`bin/agilai-claude`) launchers now validate that the Codex and Claude CLIs are installed **before** spawning the orchestrator session. If a binary is missing, the script will:
 
 - Offer an interactive menu with installation helpers (for example `npm exec --yes @openai/codex-cli@latest -- codex --help`, Homebrew taps, and the official download docs).
 - Fall back to printing the same guidance when running in non-interactive contexts (CI, redirected stdin/stdout) so automation jobs fail fast but still surface the remediation steps.
@@ -293,10 +293,10 @@ npm run build:mcp
 ls -la dist/mcp/mcp/
 ```
 
-### Permission denied on Agilai Claude (`bin/bmad-claude`)
+### Permission denied on Agilai Claude (`bin/agilai-claude`)
 
 ```bash
-chmod +x bin/bmad-claude
+chmod +x bin/agilai-claude
 ```
 
 ### No deliverables generated

--- a/docs/installation-methods.md
+++ b/docs/installation-methods.md
@@ -73,14 +73,14 @@ npx agilai@latest init
 npm install
 
 # Start chatting
-npm run bmad              # Prompts for assistant choice
-npm run bmad:claude       # Claude front-end
-npm run bmad:codex        # Codex front-end
-npm run bmad:opencode     # OpenCode front-end
+npm run agilai              # Prompts for assistant choice
+npm run agilai:claude       # Claude front-end
+npm run agilai:codex        # Codex front-end
+npm run agilai:opencode     # OpenCode front-end
 
 # Use GLM provider
-npm run bmad -- --glm
-npm run bmad:claude -- --glm
+npm run agilai -- --glm
+npm run agilai:claude -- --glm
 ```
 
 ## Option 3: Global Installation
@@ -124,10 +124,10 @@ npm install
 npm run build:mcp
 
 # Start conversational interface
-npm run bmad                # Prompts for choice
-npm run bmad:claude         # Claude CLI
-npm run bmad:codex          # Codex CLI
-npm run bmad:opencode       # OpenCode CLI
+npm run agilai                # Prompts for choice
+npm run agilai:claude         # Claude CLI
+npm run agilai:codex          # Codex CLI
+npm run agilai:opencode       # OpenCode CLI
 ```
 
 ### Development Commands
@@ -164,11 +164,11 @@ Use ZhipuAI's GLM models with the `--glm` flag:
 
 ```bash
 # CLI flag
-npm run bmad -- --glm
+npm run agilai -- --glm
 npx agilai@latest start --glm
 
 # Or explicit provider
-npm run bmad -- --llm-provider=glm
+npm run agilai -- --llm-provider=glm
 ```
 
 **Required environment variables:**
@@ -192,11 +192,11 @@ Use Anthropic's Claude models (default behavior):
 
 ```bash
 # CLI flag
-npm run bmad -- --anthropic
+npm run agilai -- --anthropic
 npx agilai@latest start --anthropic
 
 # Or explicit provider
-npm run bmad -- --llm-provider=claude
+npm run agilai -- --llm-provider=claude
 ```
 
 **Environment variables:**
@@ -215,10 +215,10 @@ Switch providers anytime with CLI flags:
 
 ```bash
 # Start with GLM
-npm run bmad -- --glm
+npm run agilai -- --glm
 
 # Later, switch to Anthropic
-npm run bmad -- --anthropic
+npm run agilai -- --anthropic
 ```
 
 Environment variable changes take effect on next launch. CLI flags override environment variables.
@@ -345,7 +345,7 @@ If using the wrong LLM provider:
 
 1. Check environment variables: `echo $LLM_PROVIDER`
 2. Verify `.env` file contents
-3. Use explicit CLI flag: `npm run bmad -- --glm` or `--anthropic`
+3. Use explicit CLI flag: `npm run agilai -- --glm` or `--anthropic`
 
 ### Permission Errors
 


### PR DESCRIPTION
## Summary
- refresh the configuration guide to highlight `npm run agilai` scripts, add guidance about the legacy `BMAD_*` environment variables, and align logging examples with the agilai service name
- update quickstart, installation, FAQ, implementation, and examples guides so the documented workflows launch the orchestrator with the agilai CLI commands
- switch the usage guide’s binary references to the agilai-prefixed launchers for Codex and Claude

## Testing
- npx prettier --config .dev/config/prettier.config.mjs --check docs/configuration.md docs/guides/QUICKSTART.md docs/examples.md docs/IMPLEMENTATION_COMPLETE.md docs/FAQ.md docs/installation-methods.md docs/guides/USAGE.md

------
https://chatgpt.com/codex/tasks/task_e_68e0911568088326bc53f0ee97bc9fab