### PR TITLE
Update ProjectState defaults to agilai

### DIFF
--- a/.dev/lib/project-state.js
+++ b/.dev/lib/project-state.js
@@ -20,7 +20,7 @@ class ProjectState {
       projectId: null,
       projectName: null,
       currentPhase: 'analyst',
-      currentLane: null, // 'bmad' or 'spec_kit'
+      currentLane: null, // 'agilai' or 'spec_kit'
       phaseHistory: [],
       laneHistory: [], // Track lane decisions
       requirements: {},
@@ -643,7 +643,7 @@ class ProjectState {
    * Get current lane
    */
   getCurrentLane() {
-    return this.state.currentLane || 'bmad';
+    return this.state.currentLane || 'agilai';
   }
 
   /**
@@ -688,7 +688,7 @@ class ProjectState {
    * Generate unique project ID
    */
   generateProjectId() {
-    return `bmad-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    return `agilai-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
   }
 }
 

--- a/.dev/test/project-state.defaults.test.js
+++ b/.dev/test/project-state.defaults.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs-extra');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ProjectState } = require('../lib/project-state');
+
+describe('ProjectState defaults', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'project-state-defaults-'));
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.remove(tempDir);
+      tempDir = null;
+    }
+  });
+
+  it('generates agilai-prefixed IDs and lane defaults for new projects', async () => {
+    const projectState = new ProjectState(tempDir);
+    const state = await projectState.initialize();
+
+    expect(state.projectId).toMatch(/^agilai-/);
+    expect(projectState.getCurrentLane()).toBe('agilai');
+  });
+
+  it('preserves legacy bmad values when loading saved state', async () => {
+    const stateDir = path.join(tempDir, '.agilai');
+    await fs.ensureDir(stateDir);
+    await fs.writeJson(
+      path.join(stateDir, 'state.json'),
+      {
+        projectId: 'bmad-legacy-id',
+        projectName: 'Legacy Project',
+        currentPhase: 'analyst',
+        currentLane: 'bmad',
+        phaseHistory: [],
+        laneHistory: [],
+        requirements: {},
+        decisions: {},
+        userPreferences: {},
+        nextSteps: '',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      { spaces: 2 },
+    );
+
+    const projectState = new ProjectState(tempDir);
+    const loadedState = await projectState.initialize();
+
+    expect(loadedState.projectId).toBe('bmad-legacy-id');
+    expect(projectState.getCurrentLane()).toBe('bmad');
+  });
+});

--- a/dist/mcp/lib/project-state.js
+++ b/dist/mcp/lib/project-state.js
@@ -20,7 +20,7 @@ class ProjectState {
       projectId: null,
       projectName: null,
       currentPhase: 'analyst',
-      currentLane: null, // 'bmad' or 'spec_kit'
+      currentLane: null, // 'agilai' or 'spec_kit'
       phaseHistory: [],
       laneHistory: [], // Track lane decisions
       requirements: {},
@@ -643,7 +643,7 @@ class ProjectState {
    * Get current lane
    */
   getCurrentLane() {
-    return this.state.currentLane || 'bmad';
+    return this.state.currentLane || 'agilai';
   }
 
   /**
@@ -688,7 +688,7 @@ class ProjectState {
    * Generate unique project ID
    */
   generateProjectId() {
-    return `bmad-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    return `agilai-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- default ProjectState lane and ID generation to the agilai prefix while preserving legacy bmad data
- add unit coverage to confirm agilai defaults and backwards compatibility when loading saved state
- rebuild the MCP bundle so the distributed project-state module reflects the new defaults

## Testing
- npx jest --config .dev/config/jest.config.cjs --runInBand --rootDir .dev project-state.defaults.test


------
https://chatgpt.com/codex/tasks/task_e_68e090afd5ac8326a8cb9fcc9dbf1e18