### PR TITLE
docs: update agilai command references

### DIFF
--- a/agents/invisible-orchestrator.md
+++ b/agents/invisible-orchestrator.md
@@ -375,15 +375,15 @@ Available tools (use throughout):
 6. **record_decision** - Save key decisions
 7. **add_conversation_message** - Track conversation
 8. **get_project_summary** - Project overview
-9. **list_bmad_agents** - See available agents (for debugging)
-10. **execute_bmad_workflow** - Run full phase workflow
+9. **list_agilai_agents** - See available agents (for debugging)
+10. **execute_agilai_workflow** - Run full phase workflow
 
 ### Brownfield Tools (for existing projects)
 
 11. **get_codebase_summary** - Complete analysis: tech stack + structure + existing docs
 12. **scan_codebase** - Detailed code structure and patterns
-13. **detect_existing_docs** - Find existing BMAD documentation
-14. **load_previous_state** - Resume from previous BMAD session
+13. **detect_existing_docs** - Find existing Agilai documentation
+14. **load_previous_state** - Resume from previous Agilai session
 
 ## Remember
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -40,7 +40,7 @@ npm run flatten                # Create XML codebase snapshot for AI analysis
 ### Installation & Setup
 ```bash
 npm run install:bmad           # Install/upgrade BMAD in target project
-npx bmad-method install        # Same as above (npx wrapper)
+npx agilai install            # Preferred NPX wrapper for installs/upgrades
 npm run setup:hooks            # Setup git hooks for validation
 ```
 
@@ -266,7 +266,7 @@ npm run mcp         # Run MCP server
 Creates AI-optimized XML snapshots of codebases:
 
 ```bash
-npx bmad-method flatten -i /path/to/source -o output.xml
+npx agilai flatten -i /path/to/source -o output.xml
 ```
 
 - Respects `.gitignore` and `.bmad-flattenignore`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -148,7 +148,7 @@ npm install
 #### 2. Start conversation
 
 ```bash
-npm run bmad
+npx agilai start
 ```
 
 #### 3. Tell the orchestrator about existing work
@@ -215,7 +215,7 @@ The orchestrator intelligently handles existing docs:
 ```bash
 # Come back days/weeks later
 cd your-project
-npm run bmad
+npx agilai start
 
 # Orchestrator automatically loads state
 Orchestrator: "Welcome back! We were working on the team todo app.
@@ -466,7 +466,7 @@ You can still:
 
 ```bash
 # Traditional BMAD (IDE-based)
-npx bmad-method install
+npx agilai install
 # Use agents directly in VS Code/Cursor/Claude Code
 
 # Agilai (conversational)
@@ -502,7 +502,7 @@ ls -la dist/mcp/mcp/server.js
 ```bash
 # Reset state (backs up old state)
 rm .agilai/state.json
-npm run bmad
+npx agilai start
 # Orchestrator will start fresh
 ```
 

--- a/docs/IMPLEMENTATION_COMPLETE.md
+++ b/docs/IMPLEMENTATION_COMPLETE.md
@@ -65,7 +65,7 @@ Successfully implemented a **fully functional MCP-based invisible orchestrator**
    - Loads orchestrator agent
    - User-friendly startup messages
 
-9. **MCP Configuration** (`.claude/mcp-config.json`, `mcp/bmad-config.json`)
+9. **MCP Configuration** (`.claude/mcp-config.json`, `mcp/agilai-config.json`)
    - Claude Code integration
    - Workspace-relative paths
 
@@ -81,16 +81,16 @@ User Types Message
 Claude CLI (with MCP)
     ↓
 MCP Server (1agilai tools)
-    ├→ get_project_context
-    ├→ detect_phase
-    ├→ load_agent_persona
-    ├→ transition_phase
-    ├→ generate_deliverable
-    ├→ record_decision
-    ├→ add_conversation_message
-    ├→ get_project_summary
-    ├→ list_bmad_agents
-    └→ execute_bmad_workflow
+     ├→ get_project_context
+     ├→ detect_phase
+     ├→ load_agent_persona
+     ├→ transition_phase
+     ├→ generate_deliverable
+     ├→ record_decision
+     ├→ add_conversation_message
+     ├→ get_project_summary
+     ├→ list_agilai_agents
+     └→ execute_agilai_workflow
     ↓
 BMAD Bridge → bmad-core agents
     ↓
@@ -124,7 +124,7 @@ npm install
 npm run build:mcp
 
 # Start conversational interface
-npm run bmad
+npx agilai start
 
 # Talk naturally
 "Help me build a task management app for my family"
@@ -216,7 +216,7 @@ npm test
 ## Success Criteria
 
 ✅ **Works without API keys** - Uses Claude Pro subscription
-✅ **Integrates with existing BMAD CLI** - npm run bmad (with `npm run bmad:claude` / `npm run bmad:codex` for specific front-ends)
+✅ **Integrates with Agilai CLI** - `npx agilai start` (with `--assistant=claude` / `--assistant=codex` for specific front-ends)
 ✅ **Generates real deliverables** - docs/ folder populated
 ✅ **Maintains invisible UX** - No methodology jargon
 ✅ **Persists state** - .agilai/ folder
@@ -235,13 +235,17 @@ npm test
 ## Usage Command
 
 ```bash
-npm run bmad
+npx agilai start
 # Or pick a specific front-end:
-# npm run bmad:claude
-# npm run bmad:codex
+# npx agilai start --assistant=claude
+# npx agilai start --assistant=codex
 ```
 
 That's literally it. Just run one command and start talking about your project!
+
+### Legacy Compatibility
+
+Need to support older automation or scripts? The legacy `npm run bmad*` aliases still ship in the package. They forward to the Agilai launcher so existing integrations continue to work while you migrate. Document any remaining dependencies on those scripts separately and plan to move them to the new `npx agilai` interface during your next maintenance window.
 
 ---
 

--- a/docs/archive/PR-opencode-agents-generator.md
+++ b/docs/archive/PR-opencode-agents-generator.md
@@ -18,7 +18,7 @@ Keep OpenCode config schema‑compliant and small, avoid key collisions, and pro
 
 ## Testing
 
-- Run: `npx bmad-method install -f -i opencode`
+- Run: `npx agilai install -f -i opencode`
 - Verify: `opencode.json[c]` updated/created as expected, `AGENTS.md` OpenCode section is compact with links
 - Pre‑push checks:
 

--- a/docs/archive/SUMMARY.md
+++ b/docs/archive/SUMMARY.md
@@ -168,15 +168,15 @@ async function runAnalystPhase(context) {
 ### NPX Usage Should Be:
 
 ```bash
-# Like BMAD
-npx bmad-method install    # Install BMAD framework
-npx bmad-method flatten    # Flatten codebase
+# Like Agilai
+npx agilai install    # Install Agilai framework
+npx agilai flatten    # Flatten codebase
 
-# BMAD-invisible should be
-npx bmad-invisible chat           # Start conversation
-npx bmad-invisible init          # Initialize project
-npx bmad-invisible status        # Show current phase
-npx bmad-invisible continue      # Resume conversation
+# Agilai Invisible should be
+npx agilai invisible chat           # Start conversation
+npx agilai invisible init          # Initialize project
+npx agilai invisible status        # Show current phase
+npx agilai invisible continue      # Resume conversation
 ```
 
 ### Chat Interface Example

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,11 +39,9 @@ Enable GLM (ZhipuAI) for the orchestrator:
 
 ```bash
 # Use GLM via flag
-npm run bmad -- --glm
 npx agilai start --glm
 
 # Explicit provider specification
-npm run bmad -- --llm-provider=glm
 npx agilai start --llm-provider=glm
 ```
 
@@ -107,16 +105,16 @@ export BMAD_ASSISTANT_PROVIDER=glm
 export BMAD_GLM_BASE_URL=https://your-glm-endpoint.com
 export BMAD_GLM_API_KEY=your-api-key
 
-# Start BMAD with GLM routing
-npm run bmad:claude
+# Start Agilai with GLM routing
+npx agilai start --assistant=claude --glm
 # Output: 🌐 GLM mode active: routing Claude CLI through configured GLM endpoint.
 ```
 
-GLM routing works with all three assistant CLIs:
+GLM routing works with all three assistant entry points:
 
-- `npm run bmad:claude` - Routes Claude CLI through GLM
-- `npm run bmad:codex` - Routes Codex CLI through GLM
-- `npm run bmad:opencode` - Routes OpenCode CLI through GLM
+- `npx agilai start --assistant=claude --glm` - Routes Claude CLI through GLM
+- `npx agilai start --assistant=codex --glm` - Routes Codex CLI through GLM
+- `npx agilai start --assistant=opencode --glm` - Routes OpenCode CLI through GLM
 
 ### Anthropic Provider (Default)
 
@@ -126,11 +124,11 @@ Using Anthropic's Claude (default behavior):
 
 ```bash
 # Use Anthropic (default)
-npm run bmad
-npm run bmad -- --anthropic
+npx agilai start
+npx agilai start --anthropic
 
 # Explicit provider
-npm run bmad -- --llm-provider=claude
+npx agilai start --llm-provider=claude
 ```
 
 #### Environment Variables
@@ -154,14 +152,14 @@ Switch providers anytime:
 
 ```bash
 # Start with GLM
-npm run bmad -- --glm
+npx agilai start --glm
 
 # Later, switch to Anthropic
-npm run bmad -- --anthropic
+npx agilai start --anthropic
 
 # Or change .env file
 echo "LLM_PROVIDER=claude" >> .env
-npm run bmad
+npx agilai start
 ```
 
 **Priority order:**
@@ -472,7 +470,7 @@ Validate your configuration:
 npm run mcp:doctor
 
 # Test LLM provider connection
-npm run bmad -- --test
+npx agilai start --test
 
 # Audit security settings
 npm run mcp:audit
@@ -532,7 +530,7 @@ If environment variables aren't being read:
 
 If using the wrong provider:
 
-1. Check CLI flag: `npm run bmad -- --glm`
+1. Check CLI flag: `npx agilai start --glm`
 2. Verify `.env` contents: `cat .env | grep LLM_PROVIDER`
 3. Check priority: CLI flags override environment variables
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,7 +16,7 @@ This example shows the complete flow for starting a new app from scratch.
 ### Example: Family Chore Tracking App
 
 ````bash
-$ npm run bmad
+$ npx agilai start
 Which assistant should we launch? (Claude / Codex / Opencode): claude
 
 🎯 Starting Agilai Orchestrator...
@@ -577,12 +577,12 @@ Agilai maintains separate contexts for different projects:
 ```bash
 # Work on project A
 cd project-a
-npm run bmad
+npx agilai start
 # Context: Project A state
 
 # Switch to project B
 cd ../project-b
-npm run bmad
+npx agilai start
 # Context: Project B state (completely separate)
 ````
 
@@ -597,7 +597,7 @@ Each project has its own:
 Agilai remembers where you left off:
 
 ```bash
-$ npm run bmad
+$ npx agilai start
 
 Welcome back! Last time we were working on:
 - Story 1.2: Assign Tasks to Family Members

--- a/docs/flattener.md
+++ b/docs/flattener.md
@@ -14,18 +14,18 @@ The BMAD-METHOD™ includes a powerful codebase flattener tool designed to prepa
 
 ```bash
 # Basic usage - creates flattened-codebase.xml in current directory
-npx bmad-method flatten
+npx agilai flatten
 
 # Specify custom input directory
-npx bmad-method flatten --input /path/to/source/directory
-npx bmad-method flatten -i /path/to/source/directory
+npx agilai flatten --input /path/to/source/directory
+npx agilai flatten -i /path/to/source/directory
 
 # Specify custom output file
-npx bmad-method flatten --output my-project.xml
-npx bmad-method flatten -o /path/to/output/codebase.xml
+npx agilai flatten --output my-project.xml
+npx agilai flatten -o /path/to/output/codebase.xml
 
 # Combine input and output options
-npx bmad-method flatten --input /path/to/source --output /path/to/output/codebase.xml
+npx agilai flatten --input /path/to/source --output /path/to/output/codebase.xml
 ```
 
 ## Example Output

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -53,13 +53,13 @@ npm install
 
 
 # Start chatting (prompts for your choice)
-npm run bmad
+npx agilai start
 # Force GLM for the orchestrator (requires ZHIPUAI_API_KEY or GLM_API_KEY)
-# npm run bmad -- --glm
+# npx agilai start --glm
 # OR use explicit commands:
-# npm run bmad:claude    # respects --glm/--anthropic flags
-# npm run bmad:codex     # respects --glm/--anthropic flags
-# npm run bmad:opencode  # respects --glm/--anthropic flags
+# npx agilai start --assistant=claude    # respects --glm/--anthropic flags
+# npx agilai start --assistant=codex     # respects --glm/--anthropic flags
+# npx agilai start --assistant=opencode  # respects --glm/--anthropic flags
 
 ```
 
@@ -94,7 +94,7 @@ npm run build:mcp
 
 
 # Start conversation (prompts for choice)
-npm run bmad
+npx agilai start
 ```
 
 #### Choosing Your LLM Provider (GLM vs Anthropic)
@@ -212,23 +212,23 @@ AI: Found 23 TODOs across 8 files. Oldest is 3 months old.
 ### Quick Commands
 
 ```bash
-npx bmad-invisible@latest start # 🚀 One-command setup and launch (prompts for choice)
-npx bmad-invisible init         # Initialize in project
-npx bmad-invisible build        # Build MCP server
-npm run bmad                    # Start conversation (prompts for assistant choice)
-npm run bmad:claude             # Start Claude directly
-npm run bmad:codex              # Start Codex directly
-npm run bmad:opencode           # Start OpenCode directly
-# Append -- --glm (or -- --anthropic) to any npm script to swap providers
+npx agilai@latest invisible start # 🚀 One-command setup and launch (prompts for choice)
+npx agilai invisible init         # Initialize in project
+npx agilai invisible build        # Build MCP server
+npx agilai start                    # Start conversation (prompts for assistant choice)
+npx agilai start --assistant=claude             # Start Claude directly
+npx agilai start --assistant=codex              # Start Codex directly
+npx agilai start --assistant=opencode           # Start OpenCode directly
+# Append --glm (or --anthropic) to any Agilai command to swap providers
 
-npx bmad-invisible test         # Run tests
-npx bmad-invisible validate     # Validate config
-npx bmad-invisible help         # Show all commands
+npx agilai invisible test         # Run tests
+npx agilai invisible validate     # Validate config
+npx agilai invisible help         # Show all commands
 ```
 
 ### Example Session
 
-Run `npm run bmad` and choose your assistant, or use direct commands (`npm run bmad:claude`, `npm run bmad:codex`, `npm run bmad:opencode`). You'll see an experience like this:
+Run `npx agilai start` and choose your assistant, or use direct commands (`npx agilai start --assistant=claude`, `npx agilai start --assistant=codex`, `npx agilai start --assistant=opencode`). You'll see an experience like this:
 
 ```
 🎯 Starting Agilai Orchestrator...

--- a/docs/guides/USAGE.md
+++ b/docs/guides/USAGE.md
@@ -36,7 +36,7 @@ npm run agilai:codex
 npm run agilai:claude
 # OpenCode front-end
 npm run agilai:opencode
-# Add -- --glm to any npm script invocation to switch providers
+# Add --glm to any Agilai invocation to switch providers
 ```
 
 > **UI Toolkit Opt-in**: When you include the optional shadcn UI helpers, the

--- a/docs/installation-methods.md
+++ b/docs/installation-methods.md
@@ -73,14 +73,14 @@ npx agilai@latest init
 npm install
 
 # Start chatting
-npm run bmad              # Prompts for assistant choice
-npm run bmad:claude       # Claude front-end
-npm run bmad:codex        # Codex front-end
-npm run bmad:opencode     # OpenCode front-end
+npx agilai start              # Prompts for assistant choice
+npx agilai start --assistant=claude       # Claude front-end
+npx agilai start --assistant=codex        # Codex front-end
+npx agilai start --assistant=opencode     # OpenCode front-end
 
 # Use GLM provider
-npm run bmad -- --glm
-npm run bmad:claude -- --glm
+npx agilai start --glm
+npx agilai start --assistant=claude --glm
 ```
 
 ## Option 3: Global Installation
@@ -124,10 +124,10 @@ npm install
 npm run build:mcp
 
 # Start conversational interface
-npm run bmad                # Prompts for choice
-npm run bmad:claude         # Claude CLI
-npm run bmad:codex          # Codex CLI
-npm run bmad:opencode       # OpenCode CLI
+npx agilai start                # Prompts for choice
+npx agilai start --assistant=claude         # Claude CLI
+npx agilai start --assistant=codex          # Codex CLI
+npx agilai start --assistant=opencode       # OpenCode CLI
 ```
 
 ### Development Commands
@@ -164,11 +164,11 @@ Use ZhipuAI's GLM models with the `--glm` flag:
 
 ```bash
 # CLI flag
-npm run bmad -- --glm
+npx agilai start --glm
 npx agilai@latest start --glm
 
 # Or explicit provider
-npm run bmad -- --llm-provider=glm
+npx agilai start --llm-provider=glm
 ```
 
 **Required environment variables:**
@@ -192,11 +192,11 @@ Use Anthropic's Claude models (default behavior):
 
 ```bash
 # CLI flag
-npm run bmad -- --anthropic
+npx agilai start --anthropic
 npx agilai@latest start --anthropic
 
 # Or explicit provider
-npm run bmad -- --llm-provider=claude
+npx agilai start --llm-provider=claude
 ```
 
 **Environment variables:**
@@ -215,10 +215,10 @@ Switch providers anytime with CLI flags:
 
 ```bash
 # Start with GLM
-npm run bmad -- --glm
+npx agilai start --glm
 
 # Later, switch to Anthropic
-npm run bmad -- --anthropic
+npx agilai start --anthropic
 ```
 
 Environment variable changes take effect on next launch. CLI flags override environment variables.
@@ -345,7 +345,7 @@ If using the wrong LLM provider:
 
 1. Check environment variables: `echo $LLM_PROVIDER`
 2. Verify `.env` file contents
-3. Use explicit CLI flag: `npm run bmad -- --glm` or `--anthropic`
+3. Use explicit CLI flag: `npx agilai start --glm` or `--anthropic`
 
 ### Permission Errors
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -193,7 +193,7 @@ If you want to do the planning on the web with Claude (Sonnet 4 or Opus), Gemini
 
 ```bash
 # Interactive installation (recommended)
-npx bmad-method install
+npx agilai install
 ```
 
 ### OpenCode
@@ -201,7 +201,7 @@ npx bmad-method install
 BMAD integrates with OpenCode via a project-level `opencode.jsonc`/`opencode.json` (JSON-only, no Markdown fallback).
 
 - Installation:
-  - Run `npx bmad-method install` and choose `OpenCode` in the IDE list.
+  - Run `npx agilai install` and choose `OpenCode` in the IDE list.
   - The installer will detect an existing `opencode.jsonc`/`opencode.json` or create a minimal `opencode.jsonc` if missing.
   - It will:
     - Ensure `instructions` includes `.bmad-core/core-config.yaml` (and each selected expansion pack’s `config.yaml`).
@@ -209,7 +209,7 @@ BMAD integrates with OpenCode via a project-level `opencode.jsonc`/`opencode.jso
     - Preserve other top-level fields and user-defined entries.
 
 - Prefixes and collisions:
-  - You can opt-in to prefix agent keys with `bmad-` and command keys with `bmad:tasks:` to avoid name collisions.
+  - You can opt-in to prefix agent keys with `agilai-` and command keys with `/agilai:tasks:` to avoid name collisions.
   - If a key already exists and is not BMAD-managed, the installer will skip it and suggest enabling prefixes.
 
 - What gets added:
@@ -229,7 +229,7 @@ BMAD integrates with OpenCode via a project-level `opencode.jsonc`/`opencode.jso
 - Refresh after changes:
   - Re-run:
     ```bash
-    npx bmad-method install -f -i opencode
+    npx agilai install -f -i opencode
     ```
   - The installer safely updates entries without duplication and preserves your custom fields and comments.
 
@@ -238,7 +238,7 @@ BMAD integrates with OpenCode via a project-level `opencode.jsonc`/`opencode.jso
     ```json
     {
       "scripts": {
-        "bmad:opencode": "bmad-method install -f -i opencode"
+        "/agilai:opencode": "agilai install -f -i opencode"
       }
     }
     ```
@@ -249,9 +249,9 @@ BMAD integrates with OpenAI Codex via `AGENTS.md` and committed core agent files
 
 - Two installation modes:
   - Codex (local only): keeps `.bmad-core/` ignored for local dev.
-    - `npx bmad-method install -f -i codex -d .`
+    - `npx agilai install -f -i codex -d .`
   - Codex Web Enabled: ensures `.bmad-core/` is tracked so you can commit it for Codex Web.
-    - `npx bmad-method install -f -i codex-web -d .`
+    - `npx agilai install -f -i codex-web -d .`
 
 - What gets generated:
   - `AGENTS.md` at the project root with a BMAD section containing
@@ -264,7 +264,7 @@ BMAD integrates with OpenAI Codex via `AGENTS.md` and committed core agent files
     `shadcn` CLI can scaffold UI components without re-prompting you for
     preferences.
   - If a `package.json` exists, helpful scripts are added:
-    - `bmad:refresh`, `bmad:list`, `bmad:validate`
+    - `/agilai:refresh`, `/agilai:list`, `/agilai:validate`
   - Global Codex CLI defaults are merged into `~/.codex/config.toml` (skipped automatically in CI/non-interactive runs).
     - Ensures Agilai's MCP server is registered and Codex approvals run in fully automated mode by default.
     - Registers optional `chrome-devtools` and `shadcn` MCP helpers with

--- a/docs/v6-migration/customization-inventory.md
+++ b/docs/v6-migration/customization-inventory.md
@@ -1,13 +1,13 @@
-# BMAD-Invisible Critical Customizations
+# Agilai Invisible Critical Customizations
 
-This inventory captures the invisible-first features that must be preserved during any migration to the BMAD V6 module architecture.
+This inventory captures the invisible-first features that must be preserved during any migration to the Agilai V6 module architecture.
 
 ## 1. MCP Server (`src/mcp-server`)
 
 ### Purpose
 
 - Hosts the invisible orchestration workflow over Model Context Protocol (MCP) so Codex and other clients can interact through stdio.
-- Orchestrates tooling exposure, lane routing, and deliverable generation without revealing BMAD internals to the user.
+- Orchestrates tooling exposure, lane routing, and deliverable generation without revealing Agilai internals to the user.
 
 ### Key Components
 
@@ -16,7 +16,7 @@ This inventory captures the invisible-first features that must be preserved duri
   - Approval-mode safety guardrails that gate sensitive operations (auto command execution, deliverable persistence, etc.).
   - Bootstraps the orchestrator runtime with lane-aware LLM clients and logs MCP availability for Codex integration.
 - **`runtime.ts`**
-  - Lazily loads BMAD core services (`ProjectState`, `BMADBridge`, deliverable generator, brownfield analyzer) and hooks modules dynamically.
+- Lazily loads Agilai core services (`ProjectState`, `BMADBridge`, deliverable generator, brownfield analyzer) and hooks modules dynamically.
   - Exposes a rich tool surface (phase detection, lane selection, deliverable generation, workflow execution) via MCP handlers.
   - Implements dual-lane execution (`quick` vs. `complex`) with explicit approval hooks and project state updates.
   - Persists lane decisions, conversation history, and deliverables through shared project state utilities.
@@ -31,7 +31,7 @@ This inventory captures the invisible-first features that must be preserved duri
 
 ### Purpose
 
-- Provides glue between invisible orchestrator and BMAD core assets (agents, tasks, templates, checklists).
+- Provides glue between invisible orchestrator and Agilai core assets (agents, tasks, templates, checklists).
 - Ensures agent personas remain discoverable and executable without exposing methodology details to the user.
 
 ### Key Capabilities
@@ -52,7 +52,7 @@ This inventory captures the invisible-first features that must be preserved duri
 
 ### Purpose
 
-- Defines the invisible-first conversational contract that hides BMAD phases, agents, and jargon from end users.
+- Defines the invisible-first conversational contract that hides Agilai phases, agents, and jargon from end users.
 - Documents mandatory MCP tool usage patterns for brownfield detection, phase transitions, and deliverable generation.
 
 ### Critical Behaviors to Preserve
@@ -82,3 +82,7 @@ This inventory captures the invisible-first features that must be preserved duri
 - [ ] Reconcile persona tool invocations with V6 command set while maintaining invisible conversational contract.
 - [ ] Port supporting hooks (phase transition, context preservation, lane selector, auto commands) into V6 lifecycle.
 - [ ] Validate deliverable outputs remain in `docs/` and maintain naming conventions for downstream tooling.
+
+### Legacy Compatibility Notes
+
+Until the V6 refactor ships, maintainers should continue shipping the legacy `.bmad-core/` tree and `npm run bmad*` scripts alongside the new Agilai tooling. Document any custom hooks or environment expectations that rely on those legacy assets so they can be rewritten or replaced before the compatibility layer is eventually removed.

--- a/docs/v6-migration/poc-report.md
+++ b/docs/v6-migration/poc-report.md
@@ -43,3 +43,7 @@
 - Plan a CommonJS→ESM rewrite (or build adapter) for `BMADBridge`, MCP runtime, and supporting hooks.
 - Define a persona/deliverable asset pipeline aligned with V6 packaging rules.
 - Update migration checklist once blockers are mitigated.
+
+## Legacy Compatibility Snapshot
+
+The current Agilai packages continue to export the legacy `bmad-core/` layout and `npm run bmad*` scripts. Keep these pathways documented for teams that have not migrated yet, but route new automation through `npx agilai` and the modular `agilai/src/modules` structure. Capture any blockers that force reliance on the legacy tree so they can be burned down before deprecating the older assets.

--- a/docs/v6-sandbox-codex-cli.md
+++ b/docs/v6-sandbox-codex-cli.md
@@ -25,7 +25,7 @@ The new defaults introduced in `lib/codex/config-manager` target the V6 CLI prof
 - Model: `GPT-5-Codex`
 - Automated approvals for both CLI tools and MCP server actions
 - MCP servers:
-  - `bmad_invisible` → `npx bmad-invisible mcp`
+  - `agilai_invisible` → `npx agilai invisible mcp`
   - Optional `chrome-devtools` and `shadcn` helpers (declared with
     `auto_start = false` until you install their binaries)
 
@@ -35,7 +35,7 @@ To (re)generate the CLI config from the sandbox, run:
 node -e "(async () => { const { ensureCodexConfig } = require('./lib/codex/config-manager.js'); const result = await ensureCodexConfig({ nonInteractive: false }); console.log('Codex config written to', result.configPath); })();"
 ```
 
-This writes/updates `~/.codex/config.toml` with the auto-approval profile and ensures the BMAD MCP server entry matches the compiled assets, while stubbing the optional helpers so Claude/Chromium tooling can be toggled on later.
+This writes/updates `~/.codex/config.toml` with the auto-approval profile and ensures the Agilai MCP server entry matches the compiled assets, while stubbing the optional helpers so Claude/Chromium tooling can be toggled on later.
 
 ## 3. Representative Chat Session Simulations
 

--- a/docs/versioning-and-releases.md
+++ b/docs/versioning-and-releases.md
@@ -67,7 +67,7 @@ The workflow automatically generates professional release notes like this:
 ## 📦 Installation
 
 ```bash
-npx bmad-method install
+npx agilai install
 ```
 ````
 
@@ -80,7 +80,7 @@ npx bmad-method install
 After any release, users can immediately get the new version with:
 
 ```bash
-npx bmad-method install    # Always gets latest release
+npx agilai install    # Always gets latest release
 ```
 
 ## 📊 Preview Before Release
@@ -125,7 +125,7 @@ We track the upstream `bmad-upstream/v6-alpha` branch for signals that BMAD V6 h
 1. **Develop Freely** - Merge PRs to main without triggering releases
 2. **Test Unreleased Changes** - Clone repo to test latest main branch
 3. **Release When Ready** - Use command line or GitHub Actions to cut releases
-4. **Users Get Updates** - Via simple `npx bmad-method install` command
+4. **Users Get Updates** - Via simple `npx agilai install` command
 
 This gives you complete control over when releases happen while automating all the tedious parts like version bumping, release notes, and publishing.
 
@@ -135,7 +135,7 @@ This gives you complete control over when releases happen while automating all t
 
 ```bash
 gh run list --workflow="Manual Release"
-npm view bmad-method dist-tags
+npm view agilai dist-tags
 git tag -l | sort -V | tail -5
 ```
 
@@ -143,7 +143,7 @@ git tag -l | sort -V | tail -5
 
 ```bash
 gh release view --web
-npm view bmad-method versions --json
+npm view agilai versions --json
 ```
 
 ### If Version Sync Needed

--- a/docs/working-in-the-brownfield.md
+++ b/docs/working-in-the-brownfield.md
@@ -32,7 +32,7 @@ If you have just completed an MVP with BMad, and you want to continue with post-
 Starting in the Web Option (potentially save some cost but a potentially more frustrating experience):
 
 1. **Follow the [<ins>User Guide - Installation</ins>](user-guide.md#installation) steps to setup your agent in the web.**
-2. **Generate a 'flattened' single file of your entire codebase** run: `npx bmad-method flatten`
+2. **Generate a 'flattened' single file of your entire codebase** run: `npx agilai flatten`
 
 Starting in an IDE with large context and good models (Its important to use quality models for this process for the best results)
 


### PR DESCRIPTION
## Summary
- replace legacy bmad command references in documentation with the new `npx agilai` and `/agilai:` equivalents
- refresh invisible orchestrator guidance to use agilai tool identifiers and mention updated MCP config naming
- call out legacy compatibility in migration and implementation reports so teams know how to bridge from the old scripts

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e09083fd548326927ca1581e0cb819