### PR TITLE
Update Codex config path handling

### DIFF
--- a/.agilai-invisible/critical-hashes.json
+++ b/.agilai-invisible/critical-hashes.json
@@ -1,6 +1,6 @@
 {
   "version": "1.3.11",
-  "generatedAt": "2025-10-04T03:14:38.649Z",
+  "generatedAt": "2025-10-04T04:31:31.238Z",
   "criticalPaths": [
     {
       "path": "agilai-core/core-config.yaml",
@@ -19,11 +19,12 @@
       "description": "Expansion packs shipped with the distribution"
     },
     {
-      "path": "codex-config.toml.example",
+      "path": ".dev/config/codex-config.toml.example",
       "description": "Default Codex CLI configuration template"
     }
   ],
   "files": {
+    ".dev/config/codex-config.toml.example": "729d8c9f44c9e8228319aaeb29f9f42ff41bee7b24e6dbbca1033663b69a0246",
     "agilai-core/checklists/architect-checklist.md": "15ef7d01b0e31c3fa1cfc7a9962958474540437b3d4958eb2a3abeacbe85d18e",
     "agilai-core/checklists/change-checklist.md": "fb2d071796c8f8b6399830aecd1cedad4a48f272124bf4bdcc8cbfb603c143d9",
     "agilai-core/checklists/pm-checklist.md": "b53f0270312713d2b9e2ee57c866e3f5077711403e67fe35aea6c313e4d49f31",

--- a/common/utils/integrity.js
+++ b/common/utils/integrity.js
@@ -21,7 +21,8 @@ const CRITICAL_PATHS = [
     description: 'Expansion packs shipped with the distribution',
   },
   {
-    path: 'codex-config.toml.example',
+    path: '.dev/config/codex-config.toml.example',
+    legacyPaths: ['codex-config.toml.example'],
     description: 'Default Codex CLI configuration template',
   },
 ];
@@ -37,6 +38,15 @@ const resolveCriticalPath = (rootDir, target) => {
   const modernPath = path.join(rootDir, target.path);
   if (fs.existsSync(modernPath)) {
     return modernPath;
+  }
+
+  if (Array.isArray(target.legacyPaths)) {
+    for (const legacy of target.legacyPaths) {
+      const legacyPath = path.join(rootDir, legacy);
+      if (fs.existsSync(legacyPath)) {
+        return legacyPath;
+      }
+    }
   }
 
   return null;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -332,7 +332,7 @@ autostart = true
   CODEX_FAST_PROVIDER = "openai"
 ```
 
-See [`codex-config.toml.example`](../codex-config.toml.example) for a ready-to-copy configuration.
+See [`codex-config.toml.example`](../.dev/config/codex-config.toml.example) for a ready-to-copy configuration.
 
 ## Observability & Logging
 

--- a/docs/guides/USAGE.md
+++ b/docs/guides/USAGE.md
@@ -189,7 +189,7 @@ baseline stored in `.agilai-invisible/critical-hashes.json`.
   - Agilai core checklists (`agilai-core/checklists/`)
   - Agilai core templates (`agilai-core/templates/`)
   - `expansion-packs/`
-  - `codex-config.toml.example`
+  - `.dev/config/codex-config.toml.example`
 
 If you intentionally customise these resources, regenerate the baseline after
 your edits:
@@ -252,7 +252,7 @@ When you include Codex CLI during installation, the wizard now also prepares you
   `auto_start = false`).
 - Sets default Codex preferences (`GPT-5-Codex`, medium reasoning, automatic approvals) without overwriting existing overrides.
 
-This step is skipped automatically in non-interactive environments. See [`codex-config.toml.example`](./codex-config.toml.example) for the full TOML structure you can tailor afterwards.
+This step is skipped automatically in non-interactive environments. See [`codex-config.toml.example`](../.dev/config/codex-config.toml.example) for the full TOML structure you can tailor afterwards.
 
 > Codex stores the MCP list in TOML tables (`[mcp_servers.<name>]`). Toggle the
 > optional helpers by switching `auto_start` to `true` once the external server

--- a/docs/installation-methods.md
+++ b/docs/installation-methods.md
@@ -261,11 +261,11 @@ autostart = true
   CODEX_METRICS_STDOUT = "true"
 ```
 
-See the full example in [`codex-config.toml.example`](../codex-config.toml.example).
+See the full example in [`codex-config.toml.example`](../.dev/config/codex-config.toml.example).
 
 ### Non-Interactive Environments
 
-CI environments skip the global config step. Review and customize [`codex-config.toml.example`](../codex-config.toml.example) for your use case.
+CI environments skip the global config step. Review and customize [`codex-config.toml.example`](../.dev/config/codex-config.toml.example) for your use case.
 
 ## MCP Configuration
 


### PR DESCRIPTION
## Summary
- update the integrity guard to prefer the new .dev/config/codex-config.toml.example path while still accepting legacy locations
- refresh documentation references to point at the relocated Codex configuration template
- regenerate the critical hash baseline to capture the new tracked path

## Testing
- node .dev/tools/update-critical-hashes.js

------
https://chatgpt.com/codex/tasks/task_e_68e0a2fd88b88326b519e9cd53b94ea1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configuration is now auto-detected in both the new and legacy example config locations for improved backward compatibility.
- Documentation
  - Updated all references to the example configuration file to its new path.
- Bug Fixes
  - Improved reliability of config path resolution by falling back to legacy locations when needed.
- Chores
  - Updated internal integrity metadata and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->