### PR TITLE
Adjust AgilaiBridge V6 test configuration

### DIFF
--- a/.dev/test/agilai-bridge.v6-mode.test.js
+++ b/.dev/test/agilai-bridge.v6-mode.test.js
@@ -2,10 +2,12 @@ const fs = require('fs-extra');
 const os = require('node:os');
 const path = require('node:path');
 
+jest.mock('../hooks/context-enrichment', () => ({}), { virtual: true });
+
 const { AgilaiBridge } = require('../lib/agilai-bridge.js');
 
 async function createV6Workspace() {
-  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'bmad-v6-workspace-'));
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'agilai-v6-workspace-'));
   const moduleRoot = path.join(tempRoot, 'src', 'modules', 'alpha');
 
   await fs.ensureDir(path.join(moduleRoot, 'agents'));
@@ -71,8 +73,8 @@ describe('AgilaiBridge V6 module detection', () => {
     });
 
     const bridge = new AgilaiBridge({
-      bmadCorePath: path.join(tempRoot, 'missing-core'),
-      bmadV6Path: tempRoot,
+      agilaiCorePath: path.join(tempRoot, 'missing-core'),
+      agilaiV6Path: tempRoot,
       llmClient: { chat: jest.fn() },
     });
 


### PR DESCRIPTION
## Summary
- update the V6 mode test to pass agilaiCorePath/agilaiV6Path to AgilaiBridge
- stub the context enrichment hook to allow the test to load the bridge module
- rename the temporary workspace prefix to match the Agilai naming

## Testing
- npm test -- .dev/test/agilai-bridge.v6-mode.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e0a3aed9248326b4c97f59e14193a0