### PR TITLE
Fix MCP lib resolver to prefer dist bundle

### DIFF
--- a/.dev/src/mcp-server/lib-resolver.ts
+++ b/.dev/src/mcp-server/lib-resolver.ts
@@ -32,7 +32,20 @@ export function resolveFromPackageRoot(...segments: string[]): string {
   return path.resolve(getPackageRoot(), ...segments);
 }
 
+const LIB_SEARCH_PATHS: string[][] = [
+  ["dist", "mcp", "lib"],
+  [".dev", "dist", "mcp", "lib"],
+  [".dev", "lib"],
+];
+
 export function resolveLibPath(moduleName: string): string {
+  for (const segments of LIB_SEARCH_PATHS) {
+    const candidatePath = resolveFromPackageRoot(...segments, moduleName);
+    if (existsSync(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
   return resolveFromPackageRoot("lib", moduleName);
 }
 

--- a/.dev/src/mcp-server/lib-resolver.ts
+++ b/.dev/src/mcp-server/lib-resolver.ts
@@ -32,6 +32,11 @@ export function resolveFromPackageRoot(...segments: string[]): string {
   return path.resolve(getPackageRoot(), ...segments);
 }
 
+// Search paths in order of preference:
+// 1. Production build output (dist/mcp/lib) - bundled distribution
+// 2. Development build output (.dev/dist/mcp/lib) - compiled TypeScript
+// 3. Development lib source (.dev/lib) - original source files
+// 4. Fallback to package lib folder (lib) - see resolveLibPath below
 const LIB_SEARCH_PATHS: string[][] = [
   ["dist", "mcp", "lib"],
   [".dev", "dist", "mcp", "lib"],

--- a/.dev/test/mcp-server-smoke.test.js
+++ b/.dev/test/mcp-server-smoke.test.js
@@ -1,0 +1,53 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+describe('MCP server bundle smoke test', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const serverEntry = path.join(repoRoot, 'dist', 'mcp', 'mcp', 'server.js');
+
+  if (!fs.existsSync(serverEntry)) {
+    throw new Error(
+      'Expected dist/mcp/mcp/server.js to exist. Run the MCP build before executing tests.',
+    );
+  }
+
+  test('server boots without missing auto-commands module', async () => {
+    await new Promise((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [
+          '-e',
+          `require(${JSON.stringify(serverEntry)});` + 'setTimeout(() => process.exit(0), 0);',
+        ],
+        {
+          cwd: repoRoot,
+          env: { ...process.env },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+
+      let stderr = '';
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+
+      child.on('error', (error) => {
+        reject(error);
+      });
+
+      child.on('exit', (code, signal) => {
+        if (code === 0) {
+          resolve(undefined);
+          return;
+        }
+
+        reject(
+          new Error(
+            `MCP server smoke test exited unexpectedly (code=${code}, signal=${signal}).\n${stderr}`,
+          ),
+        );
+      });
+    });
+  });
+});

--- a/.dev/test/mcp-server-smoke.test.js
+++ b/.dev/test/mcp-server-smoke.test.js
@@ -6,20 +6,19 @@ describe('MCP server bundle smoke test', () => {
   const repoRoot = path.resolve(__dirname, '..', '..');
   const serverEntry = path.join(repoRoot, 'dist', 'mcp', 'mcp', 'server.js');
 
-  if (!fs.existsSync(serverEntry)) {
-    throw new Error(
-      'Expected dist/mcp/mcp/server.js to exist. Run the MCP build before executing tests.',
-    );
-  }
-
   test('server boots without missing auto-commands module', async () => {
+    if (!fs.existsSync(serverEntry)) {
+      throw new Error(
+        'Expected dist/mcp/mcp/server.js to exist. Run the MCP build before executing tests.',
+      );
+    }
+
+    const script = `require(${JSON.stringify(serverEntry)}); setTimeout(() => process.exit(0), 0);`;
+
     await new Promise((resolve, reject) => {
       const child = spawn(
         process.execPath,
-        [
-          '-e',
-          `require(${JSON.stringify(serverEntry)});` + 'setTimeout(() => process.exit(0), 0);',
-        ],
+        ['-e', script],
         {
           cwd: repoRoot,
           env: { ...process.env },

--- a/dist/codex/lib-resolver.js
+++ b/dist/codex/lib-resolver.js
@@ -83,7 +83,18 @@ function getPackageRoot() {
 function resolveFromPackageRoot(...segments) {
   return path.resolve(getPackageRoot(), ...segments);
 }
+const LIB_SEARCH_PATHS = [
+  ['dist', 'mcp', 'lib'],
+  ['.dev', 'dist', 'mcp', 'lib'],
+  ['.dev', 'lib'],
+];
 function resolveLibPath(moduleName) {
+  for (const segments of LIB_SEARCH_PATHS) {
+    const candidatePath = resolveFromPackageRoot(...segments, moduleName);
+    if ((0, node_fs_1.existsSync)(candidatePath)) {
+      return candidatePath;
+    }
+  }
   return resolveFromPackageRoot('lib', moduleName);
 }
 async function importLibModule(moduleName) {

--- a/dist/codex/lib-resolver.js
+++ b/dist/codex/lib-resolver.js
@@ -83,6 +83,11 @@ function getPackageRoot() {
 function resolveFromPackageRoot(...segments) {
   return path.resolve(getPackageRoot(), ...segments);
 }
+// Search paths in order of preference:
+// 1. Production build output (dist/mcp/lib) - bundled distribution
+// 2. Development build output (.dev/dist/mcp/lib) - compiled TypeScript
+// 3. Development lib source (.dev/lib) - original source files
+// 4. Fallback to package lib folder (lib) - see resolveLibPath below
 const LIB_SEARCH_PATHS = [
   ['dist', 'mcp', 'lib'],
   ['.dev', 'dist', 'mcp', 'lib'],

--- a/dist/mcp/src/mcp-server/lib-resolver.js
+++ b/dist/mcp/src/mcp-server/lib-resolver.js
@@ -83,7 +83,18 @@ function getPackageRoot() {
 function resolveFromPackageRoot(...segments) {
   return path.resolve(getPackageRoot(), ...segments);
 }
+const LIB_SEARCH_PATHS = [
+  ['dist', 'mcp', 'lib'],
+  ['.dev', 'dist', 'mcp', 'lib'],
+  ['.dev', 'lib'],
+];
 function resolveLibPath(moduleName) {
+  for (const segments of LIB_SEARCH_PATHS) {
+    const candidatePath = resolveFromPackageRoot(...segments, moduleName);
+    if ((0, node_fs_1.existsSync)(candidatePath)) {
+      return candidatePath;
+    }
+  }
   return resolveFromPackageRoot('lib', moduleName);
 }
 async function importLibModule(moduleName) {

--- a/dist/mcp/src/mcp-server/lib-resolver.js
+++ b/dist/mcp/src/mcp-server/lib-resolver.js
@@ -83,6 +83,11 @@ function getPackageRoot() {
 function resolveFromPackageRoot(...segments) {
   return path.resolve(getPackageRoot(), ...segments);
 }
+// Search paths in order of preference:
+// 1. Production build output (dist/mcp/lib) - bundled distribution
+// 2. Development build output (.dev/dist/mcp/lib) - compiled TypeScript
+// 3. Development lib source (.dev/lib) - original source files
+// 4. Fallback to package lib folder (lib) - see resolveLibPath below
 const LIB_SEARCH_PATHS = [
   ['dist', 'mcp', 'lib'],
   ['.dev', 'dist', 'mcp', 'lib'],


### PR DESCRIPTION
## Summary
- update the MCP lib resolver to look for helper modules in dist/mcp/lib and other build outputs before falling back to the package lib folder
- refresh the compiled JavaScript bundles so they mirror the new lookup behaviour
- add a smoke test that runs the bundled MCP server to ensure auto-commands can be resolved in a fresh checkout

## Testing
- npm test -- mcp-server-smoke

------
https://chatgpt.com/codex/tasks/task_e_68e0a87c9f748326b6fbcd7ec095d544