### PR TITLE
Fix MCP orchestrator command to use Node module resolution

### DIFF
--- a/bin/agilai
+++ b/bin/agilai
@@ -1124,9 +1124,14 @@ const commands = {
     }
 
     const orchestratorKey = 'agilai-invisible-orchestrator';
+    const orchestratorArgs = ['-e', "require('agilai/dist/mcp/mcp/server.js')"];
+    const legacyOrchestratorArgs = new Set([
+      'dist/mcp/mcp/server.js',
+      './node_modules/agilai/dist/mcp/mcp/server.js',
+    ]);
     const orchestratorConfig = {
       command: 'node',
-      args: ['./node_modules/agilai/dist/mcp/mcp/server.js'],
+      args: [...orchestratorArgs],
       disabled: false,
     };
 
@@ -1135,7 +1140,19 @@ const commands = {
       console.log('✅ Added Agilai orchestrator MCP server');
     } else {
       // Ensure orchestrator is enabled during re-init (user may have disabled it)
-      mcpConfig.mcpServers[orchestratorKey].disabled = false;
+      const existing = mcpConfig.mcpServers[orchestratorKey];
+      existing.disabled = false;
+      existing.command = 'node';
+
+      if (!Array.isArray(existing.args) || existing.args.length === 0) {
+        existing.args = [...orchestratorArgs];
+      } else if (
+        existing.args.length === 1 &&
+        typeof existing.args[0] === 'string' &&
+        legacyOrchestratorArgs.has(existing.args[0])
+      ) {
+        existing.args = [...orchestratorArgs];
+      }
     }
 
     const promptYesNo = async (question) => {

--- a/docs/guides/USAGE.md
+++ b/docs/guides/USAGE.md
@@ -228,7 +228,7 @@ npm run build
 npm run mcp
 
 # Or with custom path
-node dist/mcp/mcp/server.js
+node -e "require('agilai/dist/mcp/mcp/server.js')"
 ```
 
 ### Using in IDEs

--- a/mcp/agilai-config.json
+++ b/mcp/agilai-config.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "agilai-invisible-orchestrator": {
       "command": "node",
-      "args": ["dist/mcp/mcp/server.js"]
+      "args": ["-e", "require('agilai/dist/mcp/mcp/server.js')"]
     },
     "chrome-devtools": {
       "command": "npx",


### PR DESCRIPTION
## Summary
- update the init command to launch the orchestrator via `node -e` so the module loader resolves the path
- heal existing `.mcp.json` files by rewriting legacy orchestrator args during init
- refresh the bundled MCP config and docs to match the new invocation

## Testing
- node /workspace/Agilai/bin/agilai init (accept defaults)


------
https://chatgpt.com/codex/tasks/task_e_68e0b3d02dd4832685808034c73b130c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improves reliability of the orchestrator startup across environments, avoiding failures caused by hard-coded paths.

- Chores
  - Automatically migrates legacy orchestrator settings during re-initialization, preserving existing servers, enabling them, and switching to the new invocation method.

- Documentation
  - Updates usage examples to reflect the new orchestrator invocation command, aligning docs with current behavior.

- Refactor
  - Standardizes how the orchestrator is launched, using a more robust, module-based startup approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->