### PR TITLE
Update MCP orchestrator launch command

### DIFF
--- a/bin/agilai
+++ b/bin/agilai
@@ -1126,7 +1126,7 @@ const commands = {
     const orchestratorKey = 'agilai-invisible-orchestrator';
     const orchestratorConfig = {
       command: 'node',
-      args: ['./node_modules/agilai/dist/mcp/mcp/server.js'],
+      args: ['-e', "require('agilai/dist/mcp/mcp/server.js')"],
       disabled: false,
     };
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -488,8 +488,8 @@ Both produce the same `docs/` structure, so you can switch between them!
 # Rebuild MCP server
 npm run build:mcp
 
-# Verify it exists
-ls -la dist/mcp/mcp/server.js
+# Verify it loads
+node -e "require('agilai/dist/mcp/mcp/server.js')"
 ```
 
 ### "Command not found: claude"

--- a/docs/guides/USAGE.md
+++ b/docs/guides/USAGE.md
@@ -228,7 +228,7 @@ npm run build
 npm run mcp
 
 # Or with custom path
-node dist/mcp/mcp/server.js
+node -e "require('agilai/dist/mcp/mcp/server.js')"
 ```
 
 ### Using in IDEs

--- a/docs/v6-sandbox-codex-cli.md
+++ b/docs/v6-sandbox-codex-cli.md
@@ -58,7 +58,7 @@ These checks give parity coverage without depending on the live Codex service wh
 ## 4. Troubleshooting Notes
 
 - **`codex` command not found** – re-run the CLI installer inside the sandbox and verify `$PATH` includes the install location.
-- **`dist/mcp/mcp/server.js` missing** – execute `npm run build:mcp` to refresh compiled MCP assets.
+- **`require('agilai/dist/mcp/mcp/server.js')` failing** – execute `npm run build:mcp` to refresh compiled MCP assets.
 - **Configuration not updating** – delete `~/.codex/config.toml` and rerun the `ensureCodexConfig` snippet to regenerate with the new defaults.
 
 ## 5. Outcome

--- a/mcp/agilai-config.json
+++ b/mcp/agilai-config.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "agilai-invisible-orchestrator": {
       "command": "node",
-      "args": ["dist/mcp/mcp/server.js"]
+      "args": ["-e", "require('agilai/dist/mcp/mcp/server.js')"]
     },
     "chrome-devtools": {
       "command": "npx",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lint": "eslint --config .dev/config/eslint.config.mjs . --ext .js,.cjs,.mjs,.yaml --max-warnings=0",
     "lint:fix": "eslint --config .dev/config/eslint.config.mjs . --ext .js,.cjs,.mjs,.yaml --fix",
     "list:agents": "node .dev/tools/cli.js list:agents",
-    "mcp": "node dist/mcp/mcp/server.js",
+    "mcp": "node -e \"require('agilai/dist/mcp/mcp/server.js')\"",
     "mcp:add": "node .dev/tools/cli.js mcp add",
     "mcp:audit": "node .dev/tools/cli.js mcp audit",
     "mcp:browse": "node .dev/tools/cli.js mcp browse",


### PR DESCRIPTION
## Summary
- update the orchestrator MCP configuration to use the new require-based launch command
- refresh CLI scripts, npm scripts, and docs to reference the path-agnostic MCP entry point

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0b3d186f0832686f70f5cf561635e