### PR TITLE
Ensure MCP build runs before packaging

### DIFF
--- a/.dev/test/postinstall-build-mcp.test.js
+++ b/.dev/test/postinstall-build-mcp.test.js
@@ -41,18 +41,12 @@ describe('postinstall-build-mcp script', () => {
       }
     });
 
-    test('exits early when no prebuilt server is found', () => {
+    test('exits early with helpful message when no prebuilt server is found', () => {
       const result = runPostinstall();
 
       expect(result.status).toBe(0);
       expect(result.stderr).toContain('Prebuilt MCP server not found');
       expect(result.stderr).toContain('npm run build:mcp');
-    });
-
-    test('exits early when prebuilt server is missing', () => {
-      const result = runPostinstall();
-
-      expect(result.status).toBe(0);
       expect(result.stderr).toContain('Skipping MCP asset sync');
     });
   });

--- a/.dev/test/prepack-mcp.integration.test.js
+++ b/.dev/test/prepack-mcp.integration.test.js
@@ -1,0 +1,222 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync, execSync } = require('node:child_process');
+
+describe('prepack MCP integration tests', () => {
+  const rootDir = path.resolve(__dirname, '..');
+  const distMcpDir = path.join(rootDir, 'dist', 'mcp');
+  const serverEntry = path.join(distMcpDir, 'mcp', 'server.js');
+
+  describe('prepack script', () => {
+    let distMcpBackup;
+
+    beforeAll(() => {
+      // Back up existing dist/mcp if it exists
+      distMcpBackup = distMcpDir + '.prepack-test-backup';
+      if (fs.existsSync(distMcpDir)) {
+        if (fs.existsSync(distMcpBackup)) {
+          fs.rmSync(distMcpBackup, { recursive: true, force: true });
+        }
+        fs.renameSync(distMcpDir, distMcpBackup);
+      }
+    });
+
+    afterAll(() => {
+      // Restore original state
+      if (fs.existsSync(distMcpDir)) {
+        fs.rmSync(distMcpDir, { recursive: true, force: true });
+      }
+      if (fs.existsSync(distMcpBackup)) {
+        fs.renameSync(distMcpBackup, distMcpDir);
+      }
+    });
+
+    test('prepack script runs build:mcp', () => {
+      const packageJson = require(path.join(rootDir, 'package.json'));
+      expect(packageJson.scripts.prepack).toBe('npm run build:mcp');
+    });
+
+    test('build:mcp creates dist/mcp/mcp/server.js', () => {
+      // Run the build:mcp script
+      const result = spawnSync('npm', ['run', 'build:mcp'], {
+        cwd: rootDir,
+        env: { ...process.env },
+        encoding: 'utf8',
+        shell: true,
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(serverEntry)).toBe(true);
+    });
+
+    test('build:mcp compiles TypeScript from .dev/mcp', () => {
+      // Run the build:mcp script
+      spawnSync('npm', ['run', 'build:mcp'], {
+        cwd: rootDir,
+        env: { ...process.env },
+        encoding: 'utf8',
+        shell: true,
+      });
+
+      // Verify TypeScript was compiled
+      expect(fs.existsSync(serverEntry)).toBe(true);
+
+      // Verify it's actual JavaScript, not TypeScript
+      const content = fs.readFileSync(serverEntry, 'utf8');
+      expect(content).not.toContain('import type');
+      expect(content).not.toContain(': string');
+    });
+
+    test('build:mcp copies lib, hooks, and tools directories', () => {
+      // Run the build:mcp script
+      spawnSync('npm', ['run', 'build:mcp'], {
+        cwd: rootDir,
+        env: { ...process.env },
+        encoding: 'utf8',
+        shell: true,
+      });
+
+      // Verify directories were created
+      const libDir = path.join(distMcpDir, 'lib');
+      const hooksDir = path.join(distMcpDir, 'hooks');
+      const toolsDir = path.join(distMcpDir, 'tools');
+
+      if (fs.existsSync(path.join(rootDir, '.dev', 'lib'))) {
+        expect(fs.existsSync(libDir)).toBe(true);
+      }
+
+      if (fs.existsSync(path.join(rootDir, 'hooks'))) {
+        expect(fs.existsSync(hooksDir)).toBe(true);
+      }
+
+      expect(fs.existsSync(toolsDir)).toBe(true);
+
+      // Verify specific tool files
+      const expectedToolFiles = [
+        'mcp-registry.js',
+        'mcp-manager.js',
+        'mcp-profiles.js',
+        'mcp-security.js',
+      ];
+
+      for (const file of expectedToolFiles) {
+        expect(fs.existsSync(path.join(toolsDir, file))).toBe(true);
+      }
+    });
+  });
+
+  describe('npm pack integration', () => {
+    let distMcpBackup;
+    let tarballPath;
+
+    beforeAll(() => {
+      // Back up existing dist/mcp if it exists
+      distMcpBackup = distMcpDir + '.pack-test-backup';
+      if (fs.existsSync(distMcpDir)) {
+        if (fs.existsSync(distMcpBackup)) {
+          fs.rmSync(distMcpBackup, { recursive: true, force: true });
+        }
+        fs.renameSync(distMcpDir, distMcpBackup);
+      }
+    });
+
+    afterAll(() => {
+      // Clean up tarball
+      if (tarballPath && fs.existsSync(tarballPath)) {
+        fs.unlinkSync(tarballPath);
+      }
+
+      // Restore original state
+      if (fs.existsSync(distMcpDir)) {
+        fs.rmSync(distMcpDir, { recursive: true, force: true });
+      }
+      if (fs.existsSync(distMcpBackup)) {
+        fs.renameSync(distMcpBackup, distMcpDir);
+      }
+    });
+
+    test('npm pack includes dist/mcp/mcp/server.js', () => {
+      // Run npm pack
+      const result = spawnSync('npm', ['pack'], {
+        cwd: rootDir,
+        env: { ...process.env },
+        encoding: 'utf8',
+        shell: true,
+      });
+
+      expect(result.status).toBe(0);
+
+      // Find the created tarball
+      const packageJson = require(path.join(rootDir, 'package.json'));
+      const expectedTarballName = `${packageJson.name}-${packageJson.version}.tgz`;
+      tarballPath = path.join(rootDir, expectedTarballName);
+
+      expect(fs.existsSync(tarballPath)).toBe(true);
+
+      // Check tarball contents for server.js
+      const listResult = spawnSync(
+        'tar',
+        ['-tzf', expectedTarballName, 'package/dist/mcp/mcp/server.js'],
+        {
+          cwd: rootDir,
+          encoding: 'utf8',
+        },
+      );
+
+      expect(listResult.status).toBe(0);
+      expect(listResult.stdout).toContain('package/dist/mcp/mcp/server.js');
+    });
+
+    test('npm pack includes MCP assets (lib, hooks, tools)', () => {
+      if (!tarballPath) {
+        // Run npm pack if not already done
+        spawnSync('npm', ['pack'], {
+          cwd: rootDir,
+          env: { ...process.env },
+          encoding: 'utf8',
+          shell: true,
+        });
+
+        const packageJson = require(path.join(rootDir, 'package.json'));
+        tarballPath = path.join(rootDir, `${packageJson.name}-${packageJson.version}.tgz`);
+      }
+
+      // List all files in the tarball
+      const listResult = spawnSync('tar', ['-tzf', path.basename(tarballPath)], {
+        cwd: rootDir,
+        encoding: 'utf8',
+      });
+
+      expect(listResult.status).toBe(0);
+
+      const tarballContents = listResult.stdout;
+
+      // Check for MCP assets if they exist in source
+      if (fs.existsSync(path.join(rootDir, '.dev', 'lib'))) {
+        expect(tarballContents).toMatch(/package\/dist\/mcp\/lib\//);
+      }
+
+      if (fs.existsSync(path.join(rootDir, 'hooks'))) {
+        expect(tarballContents).toMatch(/package\/dist\/mcp\/hooks\//);
+      }
+
+      expect(tarballContents).toMatch(/package\/dist\/mcp\/tools\//);
+    });
+  });
+
+  describe('postinstall after npm pack flow', () => {
+    test('postinstall runs successfully after installing from tarball', () => {
+      // This test verifies the complete flow:
+      // 1. prepack builds MCP
+      // 2. npm pack creates tarball with dist/mcp
+      // 3. npm install from tarball runs postinstall
+      // 4. postinstall finds prebuilt server and copies assets
+
+      // Note: This is a conceptual test - actual tarball install testing
+      // requires a separate test environment to avoid polluting node_modules
+      const packageJson = require(path.join(rootDir, 'package.json'));
+      expect(packageJson.scripts.postinstall).toBe('node .dev/tools/postinstall-build-mcp.js');
+      expect(packageJson.scripts.prepack).toBe('npm run build:mcp');
+    });
+  });
+});

--- a/.dev/tools/postinstall-build-mcp.js
+++ b/.dev/tools/postinstall-build-mcp.js
@@ -16,19 +16,12 @@ const rootDir = path.resolve(__dirname, '..');
 const distMcpDir = path.join(rootDir, 'dist', 'mcp');
 const serverEntry = path.join(distMcpDir, 'mcp', 'server.js');
 
-// Check for --force flag
-const forceRebuild = process.argv.includes('--force');
-
 const hasPrebuiltServer = existsSync(serverEntry);
 
-if (!hasPrebuiltServer && !forceRebuild) {
+if (!hasPrebuiltServer) {
   console.warn('⚠️  Prebuilt MCP server not found at dist/mcp/mcp/server.js.');
   console.warn('    Skipping MCP asset sync. Run "npm run build:mcp" to generate the build.');
   process.exit(0);
-}
-
-if (!hasPrebuiltServer && forceRebuild) {
-  console.warn('⚠️  --force supplied but no MCP server present; continuing with asset copy.');
 }
 
 ensureDir(distMcpDir);

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "mcp:search": "node .dev/tools/cli.js mcp search",
     "mcp:secure": "node .dev/tools/cli.js mcp secure",
     "mcp:suggest": "node .dev/tools/cli.js mcp suggest",
+    "prepack": "npm run build:mcp",
     "pre-release": "npm run validate && npm run format:check && npm run lint",
     "prepare": "husky",
     "preview:release": "node .dev/tools/preview-release-notes.js",


### PR DESCRIPTION
## Summary
- run the MCP build during the package prepack step so dist assets are ready before publishing
- simplify the postinstall safety net to only copy assets when a prebuilt MCP server is present

## Testing
- npm run build:mcp
- npm pack
- tar -tzf agilai-1.3.21.tgz | grep "dist/mcp/mcp/server.js"
- npm install ./agilai-1.3.21.tgz --no-save
- node -e "require('./node_modules/agilai/dist/mcp/mcp/server.js'); console.log('server loaded');"


------
https://chatgpt.com/codex/tasks/task_e_68e0eba3a3948326b62f38e045c6e0c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Faster, quieter installation: postinstall no longer performs full builds and only synchronizes prebuilt runtime assets when present.
  * Added a prepack step to build MCP assets before packaging so published packages include required artifacts.
  * Clearer install-time messaging guiding users to run the MCP build when prebuilt assets are missing.

* **Refactor**
  * Simplified install flow to copy prebuilt assets only when available; removed install-time compilation.

* **Tests**
  * Expanded tests covering prepack, packaging, and postinstall synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->