### PR TITLE
chore: bump version to 1.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.3.24](https://github.com/bacoco/Agilai/compare/v1.3.23...v1.3.24) (2025-10-04)
+
+### Maintenance
+
+- Bump package version to 1.3.24 to prepare the next release.
+
 ## [1.3.11](https://github.com/bacoco/Agilai/compare/v1.3.10...v1.3.11) (2025-01-03)
 
 ### Improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "bmad-invisible",
-  "version": "1.3.23",
+  "name": "agilai",
+  "version": "1.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bmad-invisible",
-      "version": "1.3.23",
+      "name": "agilai",
+      "version": "1.3.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25,8 +25,8 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "bmad-invisible": "bin/bmad-invisible",
-        "bmad-invisible-codex": "bin/bmad-codex"
+        "agilai": "bin/agilai",
+        "agilai-codex": "bin/agilai-codex"
       },
       "devDependencies": {
         "@eslint/js": "^9.34.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "agilai",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "description": "Universal AI agent framework with MCP integration - Chat naturally, get professional results",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- bump the published version to 1.3.24 and align package metadata
- record the 1.3.24 maintenance release in the changelog

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68e0f79dc04c8326a7d8cd4f1950e34c