### PR TITLE
Allow MCP server to bypass LLM API key validation

### DIFF
--- a/.dev/lib/llm-client.js
+++ b/.dev/lib/llm-client.js
@@ -131,6 +131,13 @@ class LLMClient {
    * @returns {Promise<string>} - LLM response
    */
   async chat(messages, options = {}) {
+    if (!this.apiKey) {
+      throw new Error(
+        `Cannot call chat methods without an API key. Provider: "${this.provider}". ` +
+          `Set the ${this.getApiKeyEnvVarName()} environment variable or provide an apiKey option.`,
+      );
+    }
+
     const systemPrompt = options.systemPrompt || '';
     const temperature = options.temperature || 0.7;
     const maxTokens = options.maxTokens || 4096;
@@ -193,6 +200,10 @@ class LLMClient {
    * @returns {Promise<string>} - Response text from Claude
    */
   async chatAnthropic(messages, options) {
+    if (!this.apiKey) {
+      throw new Error('Cannot call Anthropic API without an API key.');
+    }
+
     const payload = {
       model: this.model,
       max_tokens: options.maxTokens,
@@ -227,6 +238,10 @@ class LLMClient {
   }
 
   async chatOpenAI(messages, options) {
+    if (!this.apiKey) {
+      throw new Error('Cannot call OpenAI API without an API key.');
+    }
+
     const apiMessages = messages.map((msg) => ({
       role: msg.role,
       content: msg.content,
@@ -261,6 +276,10 @@ class LLMClient {
   }
 
   async chatGemini(messages, options) {
+    if (!this.apiKey) {
+      throw new Error('Cannot call Gemini API without an API key.');
+    }
+
     // Format messages for Gemini
     const contents = [];
 
@@ -308,6 +327,10 @@ class LLMClient {
   }
 
   async chatGLM(messages, options) {
+    if (!this.apiKey) {
+      throw new Error('Cannot call GLM API without an API key.');
+    }
+
     const apiMessages = messages.map((msg) => ({
       role: msg.role,
       content: msg.content,

--- a/.dev/lib/llm-client.js
+++ b/.dev/lib/llm-client.js
@@ -7,18 +7,28 @@ const https = require('node:https');
 
 class LLMClient {
   constructor(options = {}) {
+    this.isMcpExecution = this.detectMcpExecution();
     this.provider = options.provider || process.env.LLM_PROVIDER || 'claude';
     this.apiKey = options.apiKey || this.getApiKeyFromEnv();
     this.model = options.model || this.getDefaultModel();
     this.maxRetries = options.maxRetries || 3;
     this.retryDelay = options.retryDelay || 1000;
 
-    if (!this.apiKey) {
+    if (!this.apiKey && !this.isMcpExecution) {
       const envVar = this.getApiKeyEnvVarName();
       throw new Error(
         `Missing API key for provider "${this.provider}". Set the ${envVar} environment variable or provide an apiKey option.`,
       );
     }
+  }
+
+  detectMcpExecution() {
+    const { argv } = process;
+    if (!Array.isArray(argv)) {
+      return false;
+    }
+
+    return argv.some((arg) => typeof arg === 'string' && arg.includes('mcp/server.js'));
   }
 
   getApiKeyFromEnv() {

--- a/.dev/test/llm-client.test.js
+++ b/.dev/test/llm-client.test.js
@@ -7,6 +7,7 @@ const { LLMClient } = require('../lib/llm-client');
 
 describe('LLMClient', () => {
   const originalEnv = process.env;
+  const originalArgv = process.argv;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
@@ -22,6 +23,7 @@ describe('LLMClient', () => {
   });
 
   afterEach(() => {
+    process.argv = originalArgv;
     jest.restoreAllMocks();
   });
 
@@ -340,5 +342,74 @@ describe('LLMClient', () => {
         maxTokens: 32,
       }),
     ).rejects.toThrow(/Invalid GLM base URL/);
+  });
+
+  describe('MCP Server Detection', () => {
+    it('detects MCP execution with published package path (Unix)', () => {
+      process.argv = ['node', 'node_modules/agilai/dist/mcp/mcp/server.js'];
+      const client = new LLMClient({ provider: 'claude' });
+      expect(client.isMcpExecution).toBe(true);
+    });
+
+    it('detects MCP execution with published package path (Windows)', () => {
+      process.argv = ['node', 'C:\\projects\\myapp\\node_modules\\agilai\\dist\\mcp\\mcp\\server.js'];
+      const client = new LLMClient({ provider: 'claude' });
+      expect(client.isMcpExecution).toBe(true);
+    });
+
+    it('detects MCP execution with relative path', () => {
+      process.argv = ['node', 'dist/mcp/mcp/server.js'];
+      const client = new LLMClient({ provider: 'claude' });
+      expect(client.isMcpExecution).toBe(true);
+    });
+
+    it('detects MCP execution in development mode', () => {
+      process.argv = ['ts-node', '.dev/mcp/server.ts'];
+      const client = new LLMClient({ provider: 'claude' });
+      expect(client.isMcpExecution).toBe(true);
+    });
+
+    it('does not detect MCP execution for similar but different paths', () => {
+      process.argv = ['node', 'backup-mcp/server.js'];
+      const client = new LLMClient({ provider: 'claude', apiKey: 'test-key' });
+      expect(client.isMcpExecution).toBe(false);
+    });
+
+    it('does not detect MCP execution for unrelated arguments', () => {
+      process.argv = ['node', 'app.js', '--config=mcp/server.json'];
+      const client = new LLMClient({ provider: 'claude', apiKey: 'test-key' });
+      expect(client.isMcpExecution).toBe(false);
+    });
+
+    it('handles non-array argv gracefully', () => {
+      const originalArgv = process.argv;
+      process.argv = null;
+      const client = new LLMClient({ provider: 'claude', apiKey: 'test-key' });
+      expect(client.isMcpExecution).toBe(false);
+      process.argv = originalArgv;
+    });
+
+    it('handles non-string arguments in argv', () => {
+      process.argv = ['node', 123, null, 'app.js'];
+      const client = new LLMClient({ provider: 'claude', apiKey: 'test-key' });
+      expect(client.isMcpExecution).toBe(false);
+    });
+
+    it('allows client initialization without API key in MCP mode', () => {
+      process.argv = ['node', 'dist/mcp/mcp/server.js'];
+      let client;
+      expect(() => {
+        client = new LLMClient({ provider: 'claude' });
+      }).not.toThrow();
+      expect(client.isMcpExecution).toBe(true);
+      expect(client.apiKey).toBeUndefined();
+    });
+
+    it('still requires API key in non-MCP mode', () => {
+      process.argv = ['node', 'app.js'];
+      expect(() => new LLMClient({ provider: 'claude' })).toThrow(
+        'Missing API key for provider "claude". Set the ANTHROPIC_API_KEY environment variable or provide an apiKey option.',
+      );
+    });
   });
 });

--- a/.dev/test/llm-client.test.js
+++ b/.dev/test/llm-client.test.js
@@ -411,5 +411,50 @@ describe('LLMClient', () => {
         'Missing API key for provider "claude". Set the ANTHROPIC_API_KEY environment variable or provide an apiKey option.',
       );
     });
+
+    it('throws error when calling chat() without API key in MCP mode', async () => {
+      process.argv = ['node', 'dist/mcp/mcp/server.js'];
+      const client = new LLMClient({ provider: 'claude' });
+
+      await expect(client.chat([{ role: 'user', content: 'Hello' }])).rejects.toThrow(
+        'Cannot call chat methods without an API key',
+      );
+    });
+
+    it('throws error when calling chatAnthropic() without API key in MCP mode', async () => {
+      process.argv = ['node', 'dist/mcp/mcp/server.js'];
+      const client = new LLMClient({ provider: 'claude' });
+
+      await expect(
+        client.chatAnthropic([{ role: 'user', content: 'Hello' }], { maxTokens: 100 }),
+      ).rejects.toThrow('Cannot call Anthropic API without an API key');
+    });
+
+    it('throws error when calling chatOpenAI() without API key in MCP mode', async () => {
+      process.argv = ['node', 'dist/mcp/mcp/server.js'];
+      const client = new LLMClient({ provider: 'openai' });
+
+      await expect(
+        client.chatOpenAI([{ role: 'user', content: 'Hello' }], { maxTokens: 100 }),
+      ).rejects.toThrow('Cannot call OpenAI API without an API key');
+    });
+
+    it('throws error when calling chatGemini() without API key in MCP mode', async () => {
+      process.argv = ['node', 'dist/mcp/mcp/server.js'];
+      const client = new LLMClient({ provider: 'gemini' });
+
+      await expect(
+        client.chatGemini([{ role: 'user', content: 'Hello' }], { maxTokens: 100 }),
+      ).rejects.toThrow('Cannot call Gemini API without an API key');
+    });
+
+    it('throws error when calling chatGLM() without API key in MCP mode', async () => {
+      process.argv = ['node', 'dist/mcp/mcp/server.js'];
+      const client = new LLMClient({ provider: 'glm' });
+
+      await expect(
+        client.chatGLM([{ role: 'user', content: 'Hello' }], { maxTokens: 100 }),
+      ).rejects.toThrow('Cannot call GLM API without an API key');
+    });
   });
 });

--- a/.dev/test/llm-client.test.js
+++ b/.dev/test/llm-client.test.js
@@ -381,6 +381,13 @@ describe('LLMClient', () => {
       expect(client.isMcpExecution).toBe(false);
     });
 
+    it('does not detect MCP execution for malicious paths as arguments', () => {
+      process.argv = ['node', 'app.js', 'malicious/dist/mcp/mcp/server.js'];
+      expect(() => new LLMClient({ provider: 'claude' })).toThrow(
+        'Missing API key for provider "claude"',
+      );
+    });
+
     it('handles non-array argv gracefully', () => {
       const originalArgv = process.argv;
       process.argv = null;
@@ -427,7 +434,7 @@ describe('LLMClient', () => {
 
       await expect(
         client.chatAnthropic([{ role: 'user', content: 'Hello' }], { maxTokens: 100 }),
-      ).rejects.toThrow('Cannot call Anthropic API without an API key');
+      ).rejects.toThrow('Cannot call chat methods without an API key');
     });
 
     it('throws error when calling chatOpenAI() without API key in MCP mode', async () => {
@@ -436,7 +443,7 @@ describe('LLMClient', () => {
 
       await expect(
         client.chatOpenAI([{ role: 'user', content: 'Hello' }], { maxTokens: 100 }),
-      ).rejects.toThrow('Cannot call OpenAI API without an API key');
+      ).rejects.toThrow('Cannot call chat methods without an API key');
     });
 
     it('throws error when calling chatGemini() without API key in MCP mode', async () => {
@@ -445,7 +452,7 @@ describe('LLMClient', () => {
 
       await expect(
         client.chatGemini([{ role: 'user', content: 'Hello' }], { maxTokens: 100 }),
-      ).rejects.toThrow('Cannot call Gemini API without an API key');
+      ).rejects.toThrow('Cannot call chat methods without an API key');
     });
 
     it('throws error when calling chatGLM() without API key in MCP mode', async () => {
@@ -454,7 +461,7 @@ describe('LLMClient', () => {
 
       await expect(
         client.chatGLM([{ role: 'user', content: 'Hello' }], { maxTokens: 100 }),
-      ).rejects.toThrow('Cannot call GLM API without an API key');
+      ).rejects.toThrow('Cannot call chat methods without an API key');
     });
   });
 });


### PR DESCRIPTION
## Summary
- detect MCP server executions when initializing the LLM client
- skip API key validation for MCP server startup so it can run without credentials

## Testing
- npm run build:mcp
- node dist/mcp/mcp/server.js

------
https://chatgpt.com/codex/tasks/task_e_68e0f79a94e88326a61d66489830a6ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-detects MCP execution mode so the app can run without an API key in that context; centralizes API-key validation to block API calls and show provider-specific messages when keys are missing.  
* **Bug Fixes**
  * More robust handling of command-line argument edge cases (platform paths, non-array/non-string argv) to prevent startup errors.  
* **Tests**
  * Adds extensive tests for MCP detection, argv edge cases, and API-key/chat behavior across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->