### PR TITLE
Remove legacy Agilai orchestrator MCP server entry

### DIFF
--- a/bin/agilai
+++ b/bin/agilai
@@ -1144,11 +1144,10 @@ const commands = {
       disabled: false,
     };
 
-    // Migrate from legacy key if it exists
-    if (mcpConfig.mcpServers[legacyOrchestratorKey] && !mcpConfig.mcpServers[orchestratorKey]) {
-      mcpConfig.mcpServers[orchestratorKey] = mcpConfig.mcpServers[legacyOrchestratorKey];
+    // Remove legacy key if present
+    if (mcpConfig.mcpServers[legacyOrchestratorKey]) {
       delete mcpConfig.mcpServers[legacyOrchestratorKey];
-      console.log('✅ Migrated Agilai MCP server to new name');
+      console.log('🗑️ Removed legacy Agilai orchestrator MCP server entry');
     }
 
     if (!mcpConfig.mcpServers[orchestratorKey]) {

--- a/bin/agilai
+++ b/bin/agilai
@@ -1144,16 +1144,42 @@ const commands = {
       disabled: false,
     };
 
-    // Remove legacy key if present
+    // Remove legacy key if present, preserving any custom configuration
     if (mcpConfig.mcpServers[legacyOrchestratorKey]) {
+      const legacyConfig = mcpConfig.mcpServers[legacyOrchestratorKey];
+
+      // Check if the new key already exists
+      if (!mcpConfig.mcpServers[orchestratorKey]) {
+        // Preserve custom configuration from legacy key if it differs from defaults
+        const hasCustomConfig =
+          legacyConfig.disabled === true ||
+          legacyConfig.env !== undefined ||
+          (Array.isArray(legacyConfig.args) && !legacyOrchestratorArgs.has(legacyConfig.args[0]));
+
+        if (hasCustomConfig) {
+          // Preserve custom settings but update the args to new path
+          mcpConfig.mcpServers[orchestratorKey] = {
+            ...legacyConfig,
+            args: orchestratorArgs
+          };
+          console.log('🗑️ Removed legacy orchestrator entry and preserved custom configuration');
+        } else {
+          // Use default config
+          mcpConfig.mcpServers[orchestratorKey] = orchestratorConfig;
+          console.log('🗑️ Removed legacy orchestrator entry');
+        }
+      } else {
+        // New key already exists, just remove legacy
+        console.log('🗑️ Removed legacy orchestrator entry (new entry already exists)');
+      }
+
       delete mcpConfig.mcpServers[legacyOrchestratorKey];
-      console.log('🗑️ Removed legacy Agilai orchestrator MCP server entry');
     }
 
     if (!mcpConfig.mcpServers[orchestratorKey]) {
       mcpConfig.mcpServers[orchestratorKey] = orchestratorConfig;
       console.log('✅ Added Agilai orchestrator MCP server');
-    } else {
+    } else if (!mcpConfig.mcpServers[legacyOrchestratorKey]) {
       // Ensure orchestrator is enabled during re-init (user may have disabled it)
       const existing = mcpConfig.mcpServers[orchestratorKey];
       existing.disabled = false;

--- a/mcp/agilai-config.json
+++ b/mcp/agilai-config.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
-    "agilai-invisible-orchestrator": {
+    "agilai": {
       "command": "node",
-      "args": ["./node_modules/agilai/dist/mcp/mcp/server.js"]
+      "args": ["node_modules/agilai/dist/mcp/mcp/server.js"],
+      "disabled": false
     },
     "chrome-devtools": {
       "command": "npx",


### PR DESCRIPTION
## Summary
- remove the legacy `agilai-invisible-orchestrator` MCP server entry instead of migrating it
- log an explicit cleanup message when the legacy key is removed

## Testing
- npx agilai@latest start *(fails: 403 Forbidden to npm registry)*
- node bin/agilai start *(fails: npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f799421c8326abd8283ab1277242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration migration for orchestrator settings: legacy entries are now removed instead of auto-migrated.
  * Added an informational log when a legacy entry is removed.

* **Chores**
  * Streamlined upgrade flow for MCP configuration handling.

* **User Impact**
  * If you relied on automatic migration from a legacy orchestrator setting, you may need to set the new orchestrator configuration explicitly after upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->