### PR TITLE
Add CLAUDE guidance file generation to installer

### DIFF
--- a/bin/agilai
+++ b/bin/agilai
@@ -1359,6 +1359,16 @@ const commands = {
         : '✅ Created MCP configuration',
     );
 
+    const claudeMdContent = `# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+`;
+    const claudeMdPath = path.join(projectRoot, 'CLAUDE.md');
+    if (!fs.existsSync(claudeMdPath)) {
+      fs.writeFileSync(claudeMdPath, claudeMdContent);
+      console.log('✅ Created CLAUDE.md guidance file');
+    }
+
     // Create docs directory
     const docsDir = path.join(projectRoot, 'docs');
     if (!fs.existsSync(docsDir)) {


### PR DESCRIPTION
## Summary
- create CLAUDE.md guidance content alongside the generated MCP config when running the installer
- ensure the file is only written once and log its creation for visibility

## Testing
- node /workspace/Agilai/bin/agilai init


------
https://chatgpt.com/codex/tasks/task_e_68e0fca426248326b22d1eb342ac5f52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI setup now automatically creates a CLAUDE.md guidance file at the project root after MCP configuration, if it doesn’t already exist.
* **Documentation**
  * Introduces an auto-generated project-root guidance file during initialization to accompany existing MCP setup and docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->