### PR TITLE
Add fallback agent search path for legacy phase detector

### DIFF
--- a/.dev/test/phase-transition.agent-loading.test.js
+++ b/.dev/test/phase-transition.agent-loading.test.js
@@ -1,0 +1,22 @@
+const path = require('node:path');
+
+jest.mock('../hooks/context-enrichment', () => ({}), { virtual: true });
+
+const { AgilaiBridge } = require('../lib/agilai-bridge.js');
+
+describe('phase transition legacy agent loading', () => {
+  test('phase-detector agent resolves from fallback search path', async () => {
+    const bridge = new AgilaiBridge({ llmClient: { chat: jest.fn() } });
+
+    await bridge.initialize();
+
+    expect(bridge.getEnvironmentInfo().mode).toBe('legacy-core');
+
+    const agent = await bridge.loadAgent('phase-detector');
+    const packageRoot = path.resolve(__dirname, '..', '..');
+
+    expect(agent.id).toBe('phase-detector');
+    expect(agent.path).toBe(path.join(packageRoot, 'agents', 'phase-detector.md'));
+    expect(agent.content).toContain('Phase Detector');
+  });
+});

--- a/.dev/test/postinstall-build-mcp.test.js
+++ b/.dev/test/postinstall-build-mcp.test.js
@@ -89,6 +89,7 @@ describe('postinstall-build-mcp script', () => {
       const libDir = path.join(distMcpDir, 'lib');
       const hooksDir = path.join(distMcpDir, 'hooks');
       const toolsDir = path.join(distMcpDir, 'tools');
+      const agentsDir = path.join(distMcpDir, 'agents');
 
       // Only check if source directories exist in the repo
       if (fs.existsSync(path.join(rootDir, '.dev', 'lib'))) {
@@ -97,6 +98,10 @@ describe('postinstall-build-mcp script', () => {
 
       if (fs.existsSync(path.join(rootDir, 'hooks'))) {
         expect(fs.existsSync(hooksDir)).toBe(true);
+      }
+
+      if (fs.existsSync(path.join(rootDir, 'agents'))) {
+        expect(fs.existsSync(agentsDir)).toBe(true);
       }
 
       expect(fs.existsSync(toolsDir)).toBe(true);

--- a/.dev/tools/postinstall-build-mcp.js
+++ b/.dev/tools/postinstall-build-mcp.js
@@ -28,6 +28,7 @@ ensureDir(distMcpDir);
 
 copyDirectory(path.join(rootDir, '.dev', 'lib'), path.join(distMcpDir, 'lib'));
 copyDirectory(path.join(rootDir, 'hooks'), path.join(distMcpDir, 'hooks'));
+copyDirectory(path.join(rootDir, 'agents'), path.join(distMcpDir, 'agents'));
 copyToolModules();
 
 function copyToolModules() {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bmad:opencode": "npm run agilai:opencode --",
     "build": "node .dev/tools/cli.js build",
     "build:agents": "node .dev/tools/cli.js build --agents-only",
-    "build:mcp": "tsc -p .dev/mcp/tsconfig.json && tsc -p .dev/config/tsconfig.codex.json && cp -r .dev/lib dist/mcp/ && cp -r hooks dist/mcp/ && node -e \"const fs=require('node:fs'); const path=require('node:path'); const dest=path.join('dist','mcp','tools'); fs.mkdirSync(dest,{recursive:true}); for (const file of ['mcp-registry.js','mcp-manager.js','mcp-profiles.js','mcp-security.js']) { fs.copyFileSync(path.join('.dev','tools',file), path.join(dest,file)); }\"",
+    "build:mcp": "tsc -p .dev/mcp/tsconfig.json && tsc -p .dev/config/tsconfig.codex.json && cp -r .dev/lib dist/mcp/ && cp -r hooks dist/mcp/ && rm -rf dist/mcp/agents && cp -r agents dist/mcp/agents && node -e \"const fs=require('node:fs'); const path=require('node:path'); const dest=path.join('dist','mcp','tools'); fs.mkdirSync(dest,{recursive:true}); for (const file of ['mcp-registry.js','mcp-manager.js','mcp-profiles.js','mcp-security.js']) { fs.copyFileSync(path.join('.dev','tools',file), path.join(dest,file)); }\"",
     "build:teams": "node .dev/tools/cli.js build --teams-only",
     "codex": "node bin/agilai-codex",
     "fix": "npm run format && npm run lint:fix",


### PR DESCRIPTION
## Summary
- add configurable legacy agent search paths so phase-detector can load without agilai-core copies
- copy the agents directory into MCP builds via prepack/postinstall workflows
- cover the phase transition fallback scenario and packaging sync with new tests

## Testing
- npm test -- --runTestsByPath .dev/test/phase-transition.agent-loading.test.js .dev/test/agilai-bridge.legacy-core.test.js .dev/test/postinstall-build-mcp.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e146f010d48326b7fb003ffdb97cae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * More resilient agent loading with prioritized search paths, deduplication, and a safe fallback, plus clearer warnings and accurate path reporting.

* Chores
  * MCP build now bundles the agents directory, resetting and repopulating it to ensure agents are included in distributions.

* Tests
  * Added coverage for legacy agent loading flow.
  * Expanded MCP build tests to verify agents are copied and available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->