### PR TITLE
Default MCP installs to Agilai config

### DIFF
--- a/.dev/src/mcp-server/runtime.ts
+++ b/.dev/src/mcp-server/runtime.ts
@@ -2005,6 +2005,15 @@ export async function runOrchestratorServer(
 
           const requestedConfig = params.config || "agilai";
           const normalisedRequest = requestedConfig.toLowerCase();
+
+          // Validate config parameter
+          const validConfigs = ["agilai", "claude", "both", "bmad"];
+          if (!validConfigs.includes(normalisedRequest)) {
+            throw new Error(
+              `Invalid config parameter: "${params.config}". Valid options are: "agilai" (default), "claude", "both", or "bmad" (legacy alias for "agilai")`
+            );
+          }
+
           const legacyAliasUsed = normalisedRequest === "bmad";
           const effectiveConfig = legacyAliasUsed ? "agilai" : normalisedRequest;
           const applyClaudeConfig =

--- a/.dev/src/mcp-server/runtime.ts
+++ b/.dev/src/mcp-server/runtime.ts
@@ -2003,7 +2003,7 @@ export async function runOrchestratorServer(
             serverConfig.env = params.envVars;
           }
 
-          const requestedConfig = params.config || "claude";
+          const requestedConfig = params.config || "agilai";
           const normalisedRequest = requestedConfig.toLowerCase();
           const legacyAliasUsed = normalisedRequest === "bmad";
           const effectiveConfig = legacyAliasUsed ? "agilai" : normalisedRequest;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+### Breaking Changes
+
+**⚠️ MCP Server Installation Default Changed** - Default configuration target updated
+
+- **New default**: MCP servers now install to Agilai configuration by default (previously defaulted to Claude Desktop configuration)
+- **Migration**: Existing code that relied on the implicit default will now target Agilai config instead of Claude config
+- **Workaround**: Explicitly specify `config: "claude"` to install to Claude Desktop configuration
+- **Options**: Use `config: "both"` to install to both configurations simultaneously
+- **Legacy alias**: `config: "bmad"` continues to work as an alias for `"agilai"`
+
 ### Features
 
 **🚀 Enhanced Project Initialization** - Complete BMAD-aligned project setup

--- a/agents/invisible-orchestrator.md
+++ b/agents/invisible-orchestrator.md
@@ -110,7 +110,7 @@ When users mention capabilities that require external tools, **proactively sugge
 
 - `search_mcp_servers({ query: "keyword" })` - Find relevant MCP servers
 - `suggest_mcp_servers()` - Get context-aware suggestions based on project
-- `install_mcp_server({ serverId: "id", envVars: {...} })` - Install and configure
+- `install_mcp_server({ serverId: "id", envVars: {...} })` - Install and configure (defaults to Agilai config; pass `config: "both"` for dual Claude/Agilai installs)
 - `list_mcp_servers()` - Show currently configured servers
 - `get_mcp_health()` - Check server health status
 - `browse_mcp_registry()` - Explore all available servers

--- a/dist/codex/runtime.js
+++ b/dist/codex/runtime.js
@@ -1734,7 +1734,7 @@ async function runOrchestratorServer(options = {}) {
           if (params.envVars && Object.keys(params.envVars).length > 0) {
             serverConfig.env = params.envVars;
           }
-          const requestedConfig = params.config || 'claude';
+          const requestedConfig = params.config || 'agilai';
           const normalisedRequest = requestedConfig.toLowerCase();
           const legacyAliasUsed = normalisedRequest === 'bmad';
           const effectiveConfig = legacyAliasUsed ? 'agilai' : normalisedRequest;

--- a/dist/mcp/src/mcp-server/runtime.js
+++ b/dist/mcp/src/mcp-server/runtime.js
@@ -1734,7 +1734,7 @@ async function runOrchestratorServer(options = {}) {
           if (params.envVars && Object.keys(params.envVars).length > 0) {
             serverConfig.env = params.envVars;
           }
-          const requestedConfig = params.config || 'claude';
+          const requestedConfig = params.config || 'agilai';
           const normalisedRequest = requestedConfig.toLowerCase();
           const legacyAliasUsed = normalisedRequest === 'bmad';
           const effectiveConfig = legacyAliasUsed ? 'agilai' : normalisedRequest;

--- a/docs/mcp-management.md
+++ b/docs/mcp-management.md
@@ -56,6 +56,28 @@ The installer will:
 3. Add to your active profile
 4. Verify the installation
 
+#### Configuration Targets
+
+By default, MCP servers are installed to the **Agilai configuration**. You can specify a different target using the `config` parameter when using the `install_mcp_server` tool:
+
+- **`config: "agilai"`** - Install to Agilai config only (default)
+- **`config: "claude"`** - Install to Claude Desktop config only
+- **`config: "both"`** - Install to both Agilai and Claude Desktop configs
+- **`config: "bmad"`** - Legacy alias for "agilai"
+
+**Example usage in agent tools:**
+
+```javascript
+// Default - installs to Agilai config
+install_mcp_server({ serverId: 'filesystem' })
+
+// Install to Claude Desktop config only
+install_mcp_server({ serverId: 'filesystem', config: 'claude' })
+
+// Install to both configs (dual-write)
+install_mcp_server({ serverId: 'filesystem', config: 'both' })
+```
+
 ### Search for Servers
 
 ```bash


### PR DESCRIPTION
## Summary
- default the install_mcp_server runtime handler to populate Agilai configs when no config is specified
- document the new default in the invisible orchestrator instructions so dual writes pass `config: "both"`
- rebuild the compiled runtimes so both MCP and Codex bundles use the updated default

## Testing
- npm run build:mcp
- node -e "const McpManager=require('./dist/mcp/tools/mcp-manager.js'); const manager=new McpManager({rootDir: process.cwd()}); const serverId='verify-default'; const serverConfig={command:'node', args:['dummy-server.js'], disabled:false}; const params={serverId}; const requestedConfig=(params.config||'agilai'); const normalisedRequest=requestedConfig.toLowerCase(); const legacyAliasUsed=normalisedRequest==='bmad'; const effectiveConfig=legacyAliasUsed?'agilai':normalisedRequest; const applyClaudeConfig=normalisedRequest==='claude'||normalisedRequest==='both'; const applyAgilaiConfig=effectiveConfig==='agilai'||normalisedRequest==='both'; if(applyClaudeConfig){ const config=manager.loadClaudeConfig(); config.mcpServers=config.mcpServers||{}; config.mcpServers[serverId]=serverConfig; manager.saveClaudeConfig(config);} if(applyAgilaiConfig){ const config=manager.loadAgilaiConfig(); config.mcpServers=config.mcpServers||{}; config.mcpServers[serverId]=serverConfig; manager.saveAgilaiConfig(config);} const updated=manager.loadAgilaiConfig(); console.log(updated.mcpServers[serverId]);"

------
https://chatgpt.com/codex/tasks/task_e_68e16dc88900832698f6518bb38d58e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server installation now defaults to the Agilai configuration.
  * Optional dual install of Claude and Agilai available via config: "both".
* **Bug Fixes / UX**
  * Installer now validates target values and returns a descriptive error for invalid choices.
* **Documentation**
  * Installation and management docs updated to explain the new default, valid config options (agilai, claude, both, bmad) and how to override defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->