### PR TITLE
Revise README dual-lane orchestration messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,15 +158,15 @@ User: "I want to build an app"
 
 Agilai automatically steers every request through the right mix of speed and depth. You never toggle a switch—the system senses complexity and elevates the workflow the moment your project needs more than a quick brief.
 
-**Quick Lane: 3-minute briefs**
+#### Quick Lane: 3-minute briefs
 
 The quick lane boots up your `docs/` workspace in minutes, generating the core folders and drafting the product requirement, architecture outline, and user stories you need to get moving. It is designed for lightweight asks where momentum matters most, giving you production-ready assets without waiting on a full committee.
 
-**Complex Lane: BMAD depth on demand**
+#### Complex Lane: BMAD depth on demand
 
 When scope grows, the complex lane inherits everything the quick lane has already staged and then unleashes the full BMAD multi-agent orchestration. Analysts deepen the research, product managers expand the PRD, architects iterate on design, and delivery experts refine stories—all while building on the same documentation spine so nothing gets lost in translation.
 
-**Seamless hand-off, consistent outcomes**
+#### Seamless hand-off, consistent outcomes
 
 Because both lanes converge on the exact same deliverables, you can trust that every project—simple or sophisticated—arrives with the same professional PRD, architecture, and story set. The automatic hand-off means you stay in flow while Agilai keeps your `docs/` assets synchronized and production-ready.
 

--- a/README.md
+++ b/README.md
@@ -156,12 +156,19 @@ User: "I want to build an app"
 
 ### Dual-Lane Orchestration
 
-Agilai intelligently routes tasks:
+Agilai automatically steers every request through the right mix of speed and depth. You never toggle a switch—the system senses complexity and elevates the workflow the moment your project needs more than a quick brief.
 
-- **Quick Lane**: Template-based rapid development (2-3 min) for simple tasks
-- **Complex Lane**: Full multi-agent BMAD workflow (10-15 min) for substantial features
+**Quick Lane: 3-minute briefs**
 
-**You never choose** - the system detects complexity automatically.
+The quick lane boots up your `docs/` workspace in minutes, generating the core folders and drafting the product requirement, architecture outline, and user stories you need to get moving. It is designed for lightweight asks where momentum matters most, giving you production-ready assets without waiting on a full committee.
+
+**Complex Lane: BMAD depth on demand**
+
+When scope grows, the complex lane inherits everything the quick lane has already staged and then unleashes the full BMAD multi-agent orchestration. Analysts deepen the research, product managers expand the PRD, architects iterate on design, and delivery experts refine stories—all while building on the same documentation spine so nothing gets lost in translation.
+
+**Seamless hand-off, consistent outcomes**
+
+Because both lanes converge on the exact same deliverables, you can trust that every project—simple or sophisticated—arrives with the same professional PRD, architecture, and story set. The automatic hand-off means you stay in flow while Agilai keeps your `docs/` assets synchronized and production-ready.
 
 → **[DUAL_LANE_ORCHESTRATION.md](docs/DUAL_LANE_ORCHESTRATION.md)** - Technical details
 


### PR DESCRIPTION
## Summary
- Replace the dual-lane orchestration bullets with a richer marketing narrative that explains automatic routing and hand-offs
- Highlight how the quick lane prepares docs assets and how the complex lane builds on them for BMAD depth
- Emphasize that both modes converge on the same deliverables to reinforce trust

## Testing
- Not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e208b3097883269b24c90d102b6a6c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Rewrote the Dual-Lane Orchestration section with clearer, user-focused descriptions.
  - Renamed and expanded “Quick Lane” to “Quick Lane: 3-minute briefs,” detailing rapid setup and core deliverables.
  - Added “Complex Lane: BMAD depth on demand” and “Seamless hand-off, consistent outcomes” subsections, outlining roles, parallel staging, and synchronized docs.
  - Emphasized consistent, production-ready deliverables across lanes.
  - Retained link to technical details for deeper reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->