### PR TITLE
Document dual-lane orchestration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,21 @@ Agilai intelligently routes tasks:
 
 **You never choose** - the system detects complexity automatically.
 
+```mermaid
+flowchart LR
+    UserRequest["User request"] --> LaneSelector["Lane selector"]
+    LaneSelector -->|Quick lane| QuickLane["Quick lane runtime"]
+    LaneSelector -->|Complex lane| ComplexLane["Complex lane workflow"]
+    QuickLane --> Docs["Shared docs/ outputs"]
+    ComplexLane --> Docs
+```
+
+**Summary:** The Quick Lane runtime sequentially loads the Spec Kit–derived spec, plan, and tasks templates—calling the LLM at each step to author `docs/prd.md`, `docs/architecture.md`, and `docs/stories/*.md`—while the Complex lane employs the multi-agent BMAD workflow to produce the same deliverables through coordinated specialists.
+
+- **Spec Kit Step – Product Spec Template** ↔ **BMAD Phase – Analyst Discovery & Product Framing**
+- **Spec Kit Step – Delivery Plan Template** ↔ **BMAD Phase – Architecture & Planning Alignment**
+- **Spec Kit Step – Tasks Template** ↔ **BMAD Phase – Story Breakdown & Delivery Execution**
+
 → **[DUAL_LANE_ORCHESTRATION.md](docs/DUAL_LANE_ORCHESTRATION.md)** - Technical details
 
 ## LLM Provider Support


### PR DESCRIPTION
## Summary
- add a mermaid diagram showing how the lane selector routes requests through the quick or complex lanes into shared docs outputs
- describe how the quick lane loads spec kit templates while the complex lane runs the multi-agent BMAD workflow to produce matching deliverables
- list the spec kit steps alongside the equivalent BMAD phases for easy comparison inside the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e20a0d85bc83268933eecd0ed7275a