### PR TITLE
Document runtime layout and exclude dev assets from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,10 +14,13 @@
 .agilai/
 .claude/
 
-# Development documentation
-docs/development/
-docs/archive/
-docs/v6-migration/
+# Developer-facing resources that are unnecessary for npx installs
+apps/
+docs/
+packages/
+prompts/
+todolist.md
+MCP_INTEGRATION_REPORT.md
 
 # Configuration files (dev only - moved to config/)
 .prettierrc

--- a/README.md
+++ b/README.md
@@ -598,6 +598,23 @@ my-project/
     └── conversation.log                # Full history
 ```
 
+## Repository layout & npm package contents
+
+AiDesigner ships a lot of assets because the conversational workflow spans agents, templates, expansion packs, and compiled MCP tooling. The table below highlights the top-level directories so you can see what is required at runtime versus what only helps maintainers. When you install via `npx aidesigner`, everything marked "Yes" is bundled; the rest is excluded through the npm ignore rules so the install stays lightweight.
+
+| Path                                                                                  | Purpose                                                                                  | Required for runtime? | Shipped with `npx`? |
+| ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------- | ------------------- |
+| `bin/`                                                                                | Node entrypoints that `npx aidesigner` executes.                                         | ✅                    | ✅                  |
+| `common/`                                                                             | Shared utilities (integrity checks, environment helpers) imported by the CLI binaries.   | ✅                    | ✅                  |
+| `dist/`                                                                               | Pre-built MCP server, codex runtime, and packaged agent/team bundles.                    | ✅                    | ✅                  |
+| `aidesigner-core/`                                                                    | Canonical agents, tasks, templates, and checklists consumed by the orchestrator bridge.  | ✅                    | ✅                  |
+| `agents/`                                                                             | Legacy agent markdown used as a fallback search path for the bridge.                     | ✅                    | ✅                  |
+| `hooks/`                                                                              | Context enrichment/transition hooks loaded by the MCP runtime.                           | ✅                    | ✅                  |
+| `expansion-packs/`                                                                    | Source material for optional industry packs—kept for integrity checks and customization. | ✅                    | ✅                  |
+| `apps/`, `docs/`, `packages/`, `prompts/`, `todolist.md`, `MCP_INTEGRATION_REPORT.md` | Developer documentation, experiments, and research notes.                                | ❌                    | ❌                  |
+
+> 📦 **Why not delete the dev directories?** They are vital for maintaining the content that gets compiled into `dist/` and for publishing new expansion packs, but they are skipped during npm publishing so they do not slow down `npx` installs.
+
 ## Contributing
 
 Contributions welcome! Key areas:


### PR DESCRIPTION
## Summary
- add a README section that explains which top-level directories are required at runtime versus dev-only assets
- update `.npmignore` so apps, docs, packages, prompts, and other dev resources are left out of the published npm package

## Testing
- not run (documentation and packaging updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e3cfc4a7a483268650b87e88e76845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized npm package contents by excluding development directories and internal files, reducing install size and extraneous assets. No runtime behavior changes.
* **Documentation**
  * Added “Repository layout & npm package contents” section explaining top-level directories, what ships with npx, and why dev resources are excluded to keep installs lean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->